### PR TITLE
Extract user badge into standalone component

### DIFF
--- a/client/src/app/app.component.html
+++ b/client/src/app/app.component.html
@@ -31,9 +31,7 @@
       ariaCurrentWhenActive="page"
       >All time</a
     >
-    @if (profile.value(); as user) {
-    <span app-badge>{{ user.name }}</span>
-    }
+    <app-user-badge></app-user-badge>
     }
   </nav>
 </header>

--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -1,13 +1,12 @@
 import { Component, inject } from '@angular/core';
 import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
-import { BadgeComponent } from './common-components/badge/badge.component';
 import { HeaderMenuComponent } from './common-components/header-menu/header-menu.component';
 import { HeaderComponent } from './common-components/header/header.component';
 import { HeadingComponent } from './common-components/heading/heading.component';
 import { MainComponent } from './common-components/main/main.component';
 import { NotificationsComponent } from './common-components/notifications/notifications.component';
 import { AuthService } from './auth.service';
-import { UserProfileService } from './user-profile.service';
+import { UserBadgeComponent } from './user-badge/user-badge.component';
 
 @Component({
   imports: [
@@ -18,8 +17,8 @@ import { UserProfileService } from './user-profile.service';
     HeaderComponent,
     HeaderMenuComponent,
     MainComponent,
-    BadgeComponent,
     NotificationsComponent,
+    UserBadgeComponent,
   ],
   selector: 'app-root',
   templateUrl: './app.component.html',
@@ -27,5 +26,4 @@ import { UserProfileService } from './user-profile.service';
 })
 export class AppComponent {
   readonly isAuthenticated = inject(AuthService).isAuthenticated;
-  readonly profile = inject(UserProfileService).profile;
 }

--- a/client/src/app/user-badge/user-badge.component.ts
+++ b/client/src/app/user-badge/user-badge.component.ts
@@ -1,0 +1,15 @@
+import { Component, inject } from '@angular/core';
+import { BadgeComponent } from '../common-components/badge/badge.component';
+import { UserProfileService } from '../user-profile.service';
+
+@Component({
+  standalone: true,
+  imports: [BadgeComponent],
+  selector: 'app-user-badge',
+  template: `@if (profile.value(); as user) {
+    <span app-badge>{{ user.name }}</span>
+  }`,
+})
+export class UserBadgeComponent {
+  readonly profile = inject(UserProfileService).profile;
+}


### PR DESCRIPTION
## Summary
Refactored the user badge display logic from `AppComponent` into a new standalone `UserBadgeComponent` to improve component modularity and separation of concerns.

## Key Changes
- Created new `UserBadgeComponent` that encapsulates the user badge display logic
  - Injects `UserProfileService` directly within the component
  - Uses Angular's new control flow syntax (`@if`) for conditional rendering
  - Imports and uses `BadgeComponent` for styling
- Updated `AppComponent` to use the new `UserBadgeComponent`
  - Removed `BadgeComponent` and `UserProfileService` imports
  - Removed `profile` property injection
  - Replaced inline badge template with `<app-user-badge></app-user-badge>` selector
  - Updated component imports to include `UserBadgeComponent`

## Implementation Details
- The new component is standalone, following Angular's modern component architecture
- User profile data access is now encapsulated within `UserBadgeComponent`, reducing `AppComponent` responsibilities
- The template logic remains functionally identical, just relocated to the specialized component

https://claude.ai/code/session_01Kr95FkbD6rG29T5hjCQF6J