### PR TITLE
Match skeleton-app profile badge design with avatar circle and mat-menu

### DIFF
--- a/client/src/app/user-badge/user-badge.component.css
+++ b/client/src/app/user-badge/user-badge.component.css
@@ -1,0 +1,23 @@
+.avatar {
+  display: inline-flex;
+  user-select: none;
+  background-color: hsl(215, 14%, 34%);
+  border-radius: 50%;
+  height: 40px;
+  justify-content: center;
+  align-items: center;
+  aspect-ratio: 1;
+  color: white;
+  font-size: 18px;
+  border: unset;
+}
+
+.profile-name {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  padding-left: var(--mat-menu-item-leading-spacing);
+  padding-right: var(--mat-menu-item-trailing-spacing);
+  min-height: 36px;
+  color: var(--mat-sys-on-surface);
+}

--- a/client/src/app/user-badge/user-badge.component.html
+++ b/client/src/app/user-badge/user-badge.component.html
@@ -1,0 +1,8 @@
+<button class="avatar" [matMenuTriggerFor]="menu">
+  {{ profile.value()?.initials }}
+</button>
+<mat-menu #menu="matMenu">
+  <span class="profile-name">
+    {{ profile.value()?.name }}
+  </span>
+</mat-menu>

--- a/client/src/app/user-badge/user-badge.component.ts
+++ b/client/src/app/user-badge/user-badge.component.ts
@@ -1,14 +1,14 @@
 import { Component, inject } from '@angular/core';
-import { BadgeComponent } from '../common-components/badge/badge.component';
+import { MatButtonModule } from '@angular/material/button';
+import { MatMenuModule } from '@angular/material/menu';
 import { UserProfileService } from '../user-profile.service';
 
 @Component({
   standalone: true,
-  imports: [BadgeComponent],
+  imports: [MatButtonModule, MatMenuModule],
   selector: 'app-user-badge',
-  template: `@if (profile.value(); as user) {
-    <span app-badge>{{ user.name }}</span>
-  }`,
+  templateUrl: './user-badge.component.html',
+  styleUrl: './user-badge.component.css',
 })
 export class UserBadgeComponent {
   readonly profile = inject(UserProfileService).profile;


### PR DESCRIPTION
Replace the inline badge with an avatar button showing user initials that opens a Material menu displaying the full name, matching the skeleton-app HeaderComponent design.

https://claude.ai/code/session_01Kr95FkbD6rG29T5hjCQF6J