### PR TITLE
Replace Azure AD security configurer with standard Spring Security JW…

### DIFF
--- a/client/src/app/strava/strava.service.spec.ts
+++ b/client/src/app/strava/strava.service.spec.ts
@@ -6,6 +6,7 @@ import {
 import { TestBed } from '@angular/core/testing';
 import { NotificationService } from '../common-components/notification.service';
 import { WithingsService } from '../withings/withings.service';
+import { ENVIRONMENT_CONFIG } from '../environment/environment.config';
 import { StravaService } from './strava.service';
 
 function setup() {
@@ -23,6 +24,7 @@ function setup() {
       StravaService,
       { provide: NotificationService, useValue: mockNotificationService },
       { provide: WithingsService, useValue: mockWithingsService },
+      { provide: ENVIRONMENT_CONFIG, useValue: { mockAuth: true } },
     ],
   });
   const service = TestBed.inject(StravaService);

--- a/client/src/app/strava/strava.service.ts
+++ b/client/src/app/strava/strava.service.ts
@@ -1,14 +1,17 @@
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { NotificationService } from '../common-components/notification.service';
+import { ENVIRONMENT_CONFIG } from '../environment/environment.config';
 import { WithingsService } from '../withings/withings.service';
 import { fetchJson } from '../utils/fetchJson';
+import { handleOAuth2Redirect } from '../utils/oauth2';
 
 @Injectable({ providedIn: 'root' })
 export class StravaService {
   private readonly http = inject(HttpClient);
   private readonly notificationService = inject(NotificationService);
   private readonly withingsService = inject(WithingsService);
+  private readonly config = inject(ENVIRONMENT_CONFIG);
   private syncPromise: Promise<void> | undefined;
 
   sync(): Promise<void> {
@@ -20,7 +23,14 @@ export class StravaService {
             method: 'post',
           })
         )
-        .catch(() => {
+        .catch((error) => {
+          if (error instanceof HttpErrorResponse && error.status === 401) {
+            const href = error.error?._links?.oauth2Login?.href;
+            if (href) {
+              handleOAuth2Redirect(this.http, href, '/api/strava/auth-token', this.config.mockAuth);
+              return;
+            }
+          }
           this.notificationService.showNotification(
             'Unable to sync with Strava',
             'error'

--- a/client/src/app/utils/error.interceptor.ts
+++ b/client/src/app/utils/error.interceptor.ts
@@ -1,4 +1,4 @@
-import { HttpInterceptorFn } from '@angular/common/http';
+import { HttpErrorResponse, HttpInterceptorFn } from '@angular/common/http';
 import { inject } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { catchError } from 'rxjs';
@@ -7,6 +7,10 @@ export const errorInterceptor: HttpInterceptorFn = (req, next) => {
   const snackBar = inject(MatSnackBar);
   return next(req).pipe(
     catchError((error) => {
+      if (error instanceof HttpErrorResponse && error.status === 401 && error.error?._links?.oauth2Login) {
+        return Promise.reject(error);
+      }
+
       snackBar.open('An error occurred. ' + error.message, 'Close', {
         duration: 3000,
         verticalPosition: 'top',

--- a/client/src/app/utils/oauth2.ts
+++ b/client/src/app/utils/oauth2.ts
@@ -1,0 +1,22 @@
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+
+export function handleOAuth2Redirect(
+  http: HttpClient,
+  authorizeUrl: string,
+  authTokenUrl: string,
+  mockAuth: boolean
+): void {
+  if (mockAuth) {
+    window.location.href = authorizeUrl;
+    return;
+  }
+
+  firstValueFrom(
+    http.post<{ token: string }>(authTokenUrl, null)
+  ).then(({ token }) => {
+    const url = new URL(authorizeUrl);
+    url.searchParams.set('auth_token', token);
+    window.location.href = url.toString();
+  });
+}

--- a/client/src/app/withings/withings.service.spec.ts
+++ b/client/src/app/withings/withings.service.spec.ts
@@ -6,6 +6,7 @@ import {
 import { TestBed } from '@angular/core/testing';
 import { WithingsService } from './withings.service';
 import { NotificationService } from '../common-components/notification.service';
+import { ENVIRONMENT_CONFIG } from '../environment/environment.config';
 
 function setup() {
   const mockNotificationService: jasmine.SpyObj<NotificationService> =
@@ -16,6 +17,7 @@ function setup() {
       provideHttpClientTesting(),
       WithingsService,
       { provide: NotificationService, useValue: mockNotificationService },
+      { provide: ENVIRONMENT_CONFIG, useValue: { mockAuth: true } },
     ],
   });
   const service = TestBed.inject(WithingsService);

--- a/client/src/app/withings/withings.service.ts
+++ b/client/src/app/withings/withings.service.ts
@@ -1,19 +1,29 @@
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { NotificationService } from '../common-components/notification.service';
+import { ENVIRONMENT_CONFIG } from '../environment/environment.config';
 import { fetchJson } from '../utils/fetchJson';
+import { handleOAuth2Redirect } from '../utils/oauth2';
 
 @Injectable({ providedIn: 'root' })
 export class WithingsService {
   private readonly http = inject(HttpClient);
   private readonly notificationService = inject(NotificationService);
+  private readonly config = inject(ENVIRONMENT_CONFIG);
   private syncPromise: Promise<void> | undefined;
 
   sync(): Promise<void> {
     if (!this.syncPromise) {
       this.syncPromise = fetchJson<void>(this.http, '/api/withings/sync', {
         method: 'post',
-      }).catch(() => {
+      }).catch((error) => {
+        if (error instanceof HttpErrorResponse && error.status === 401) {
+          const href = error.error?._links?.oauth2Login?.href;
+          if (href) {
+            handleOAuth2Redirect(this.http, href, '/api/withings/auth-token', this.config.mockAuth);
+            return;
+          }
+        }
         this.notificationService.showNotification(
           'Unable to sync with Withings',
           'error'

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -64,10 +64,6 @@
       <artifactId>spring-boot-starter-security-oauth2-resource-server</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.azure.spring</groupId>
-      <artifactId>spring-cloud-azure-starter-active-directory</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-oauth2-client</artifactId>
     </dependency>

--- a/server/src/main/java/mucsi96/traininglog/core/AuthTokenService.java
+++ b/server/src/main/java/mucsi96/traininglog/core/AuthTokenService.java
@@ -1,0 +1,43 @@
+package mucsi96.traininglog.core;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthTokenService {
+
+  private static final long TOKEN_TTL_SECONDS = 300;
+
+  private record TokenEntry(String principalName, Instant expiresAt) {
+  }
+
+  private final Map<String, TokenEntry> tokens = new ConcurrentHashMap<>();
+
+  public String generateToken(String principalName) {
+    String token = UUID.randomUUID().toString();
+    tokens.put(token, new TokenEntry(principalName, Instant.now().plusSeconds(TOKEN_TTL_SECONDS)));
+    return token;
+  }
+
+  public String validateAndConsume(String token) {
+    if (token == null) {
+      return null;
+    }
+    TokenEntry entry = tokens.remove(token);
+    if (entry == null || entry.expiresAt().isBefore(Instant.now())) {
+      return null;
+    }
+    return entry.principalName();
+  }
+
+  @Scheduled(fixedRate = 60000)
+  void cleanupExpiredTokens() {
+    Instant now = Instant.now();
+    tokens.entrySet().removeIf(entry -> entry.getValue().expiresAt().isBefore(now));
+  }
+}

--- a/server/src/main/java/mucsi96/traininglog/core/SecurityConfiguration.java
+++ b/server/src/main/java/mucsi96/traininglog/core/SecurityConfiguration.java
@@ -1,28 +1,58 @@
 package mucsi96.traininglog.core;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
-import org.springframework.security.config.Customizer;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.web.SecurityFilterChain;
-
-import com.azure.spring.cloud.autoconfigure.implementation.aad.security.AadResourceServerHttpSecurityConfigurer;
 
 @Profile({"prod", "local"})
 @Configuration
 @EnableMethodSecurity(prePostEnabled = true)
+@EnableScheduling
 public class SecurityConfiguration {
+
+    @Bean
+    JwtAuthenticationConverter jwtAuthenticationConverter() {
+        JwtAuthenticationConverter converter = new JwtAuthenticationConverter();
+        converter.setJwtGrantedAuthoritiesConverter(jwt -> {
+            List<GrantedAuthority> authorities = new ArrayList<>();
+
+            List<String> roles = jwt.getClaimAsStringList("roles");
+            if (roles != null) {
+                roles.forEach(role -> authorities.add(
+                        new SimpleGrantedAuthority("APPROLE_" + role)));
+            }
+
+            String scp = jwt.getClaimAsString("scp");
+            if (scp != null) {
+                Arrays.stream(scp.split(" "))
+                        .forEach(scope -> authorities.add(
+                                new SimpleGrantedAuthority("SCOPE_" + scope)));
+            }
+
+            return authorities;
+        });
+        return converter;
+    }
 
     @Bean
     @Order(3)
     SecurityFilterChain securityFilterChain(HttpSecurity http)
             throws Exception {
 
-        http.with(AadResourceServerHttpSecurityConfigurer.aadResourceServer(),
-                Customizer.withDefaults());
+        http.oauth2ResourceServer(oauth2 -> oauth2
+                .jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter())));
 
         http.authorizeHttpRequests(requests -> requests
                 .requestMatchers("/environment").permitAll()

--- a/server/src/main/java/mucsi96/traininglog/core/TestSecurityConfiguration.java
+++ b/server/src/main/java/mucsi96/traininglog/core/TestSecurityConfiguration.java
@@ -3,17 +3,17 @@ package mucsi96.traininglog.core;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-import org.springframework.core.annotation.Order;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Profile("test")
 @Configuration
+@EnableScheduling
 public class TestSecurityConfiguration {
 
     @Bean
-    @Order(3)
     public SecurityFilterChain testSecurityFilterChain(HttpSecurity http) throws Exception {
         http
             .csrf(AbstractHttpConfigurer::disable)

--- a/server/src/main/java/mucsi96/traininglog/strava/StravaConfiguration.java
+++ b/server/src/main/java/mucsi96/traininglog/strava/StravaConfiguration.java
@@ -5,8 +5,10 @@ import java.util.Set;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
@@ -23,6 +25,7 @@ import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizedCli
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
 import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -44,14 +47,17 @@ public class StravaConfiguration {
 
   @Bean
   @Order(1)
-  SecurityFilterChain stravaSecurityFilterChain(HttpSecurity http) throws Exception {
+  @Profile({"prod", "local"})
+  SecurityFilterChain stravaSecurityFilterChain(HttpSecurity http,
+      JwtAuthenticationConverter jwtAuthenticationConverter) throws Exception {
     return http
         .securityMatcher("/strava/**")
         .csrf(AbstractHttpConfigurer::disable)
-        .oauth2Client(configurer -> configurer
-        .authorizationCodeGrant(customizer -> customizer
-        .accessTokenResponseClient(stravaAccessTokenResponseClient())))
-        .authorizeHttpRequests(authorize -> authorize.anyRequest().authenticated())
+        .oauth2ResourceServer(oauth2 -> oauth2
+            .jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter)))
+        .authorizeHttpRequests(authorize -> authorize
+            .requestMatchers(HttpMethod.GET, "/strava/authorize").permitAll()
+            .anyRequest().authenticated())
         .build();
   }
 

--- a/server/src/main/java/mucsi96/traininglog/strava/StravaController.java
+++ b/server/src/main/java/mucsi96/traininglog/strava/StravaController.java
@@ -3,41 +3,67 @@ package mucsi96.traininglog.strava;
 import java.time.ZoneId;
 import java.util.Map;
 
+import org.springframework.core.env.Environment;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
 import org.springframework.security.oauth2.core.OAuth2AuthorizationException;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationExchange;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationResponse;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import org.springframework.web.servlet.view.RedirectView;
-
-import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import mucsi96.traininglog.core.AuthTokenService;
 import mucsi96.traininglog.rides.RideService;
 
 @RestController
 @RequestMapping("/strava")
 @RequiredArgsConstructor
-@PreAuthorize("hasAuthority('APPROLE_WorkoutCreator') and hasAuthority('SCOPE_createWorkout')")
 @Slf4j
 public class StravaController {
+
+  private static final String TEST_PRINCIPAL = "rob";
 
   private final StravaActivityService stravaActivityService;
   private final RideService rideService;
   private final OAuth2AuthorizedClientManager stravaAuthorizedClientManager;
+  private final AuthTokenService authTokenService;
+  private final ClientRegistrationRepository clientRegistrationRepository;
+  private final OAuth2AuthorizedClientRepository authorizedClientRepository;
+  private final StravaConfiguration stravaConfiguration;
+  private final Environment environment;
+
+  @PostMapping("/auth-token")
+  @PreAuthorize("hasAuthority('APPROLE_WorkoutCreator') and hasAuthority('SCOPE_createWorkout')")
+  public Map<String, String> createAuthToken(Authentication principal) {
+    String token = authTokenService.generateToken(principal.getName());
+    return Map.of("token", token);
+  }
 
   @PostMapping("/activities/sync")
+  @PreAuthorize("hasAuthority('APPROLE_WorkoutCreator') and hasAuthority('SCOPE_createWorkout')")
   public ResponseEntity<?> syncActivities(
       Authentication principal,
       HttpServletRequest servletRequest,
@@ -51,7 +77,7 @@ public class StravaController {
       stravaActivityService.getTodayRides(authorizedClient, zoneId).forEach(rideService::saveRide);
     } catch (OAuth2AuthorizationException ex) {
       String authorizeUrl = ServletUriComponentsBuilder.fromRequestUri(servletRequest)
-          .replacePath("/strava/authorize").toUriString();
+          .replacePath(servletRequest.getContextPath() + "/strava/authorize").toUriString();
       return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
           .body(Map.of("_links", Map.of("oauth2Login", Map.of("href", authorizeUrl))));
     }
@@ -61,12 +87,98 @@ public class StravaController {
 
   @GetMapping("/authorize")
   public RedirectView authorize(
-      Authentication principal,
+      @RequestParam(name = "auth_token", required = false) String authToken,
+      @RequestParam(name = "code", required = false) String code,
+      @RequestParam(name = "state", required = false) String state,
       HttpServletRequest servletRequest,
       HttpServletResponse servletResponse) {
-    log.info("authorizing Strava client");
-    getAuthorizedClient(principal, servletRequest, servletResponse);
+
+    if (code != null && state != null) {
+      return handleCallback(code, state, servletRequest, servletResponse);
+    }
+
+    String principalName = resolvePrincipalName(authToken);
+    return initiateAuthorization(principalName, servletRequest);
+  }
+
+  private String resolvePrincipalName(String authToken) {
+    if (authToken != null) {
+      String principalName = authTokenService.validateAndConsume(authToken);
+      if (principalName != null) {
+        return principalName;
+      }
+    }
+    if (environment.matchesProfiles("test")) {
+      return TEST_PRINCIPAL;
+    }
+    throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid or expired auth token");
+  }
+
+  private RedirectView initiateAuthorization(String principalName, HttpServletRequest request) {
+    ClientRegistration registration = clientRegistrationRepository
+        .findByRegistrationId(StravaConfiguration.registrationId);
+    String redirectUri = buildRedirectUri(request);
+    String stateValue = authTokenService.generateToken(principalName);
+
+    String authUrl = UriComponentsBuilder
+        .fromUriString(registration.getProviderDetails().getAuthorizationUri())
+        .queryParam("client_id", registration.getClientId())
+        .queryParam("redirect_uri", redirectUri)
+        .queryParam("response_type", "code")
+        .queryParam("scope", String.join(" ", registration.getScopes()))
+        .queryParam("state", stateValue)
+        .build().toUriString();
+
+    log.info("Redirecting to Strava authorization: {}", authUrl);
+    return new RedirectView(authUrl);
+  }
+
+  private RedirectView handleCallback(String code, String state,
+      HttpServletRequest request, HttpServletResponse response) {
+    String principalName = authTokenService.validateAndConsume(state);
+    if (principalName == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid or expired state");
+    }
+
+    ClientRegistration registration = clientRegistrationRepository
+        .findByRegistrationId(StravaConfiguration.registrationId);
+    String redirectUri = buildRedirectUri(request);
+
+    OAuth2AuthorizationRequest authRequest = OAuth2AuthorizationRequest.authorizationCode()
+        .clientId(registration.getClientId())
+        .authorizationUri(registration.getProviderDetails().getAuthorizationUri())
+        .redirectUri(redirectUri)
+        .scopes(registration.getScopes())
+        .state(state)
+        .build();
+
+    OAuth2AuthorizationResponse authResponse = OAuth2AuthorizationResponse.success(code)
+        .redirectUri(redirectUri)
+        .state(state)
+        .build();
+
+    OAuth2AuthorizationExchange exchange = new OAuth2AuthorizationExchange(authRequest, authResponse);
+    var grantRequest = new org.springframework.security.oauth2.client.endpoint.OAuth2AuthorizationCodeGrantRequest(
+        registration, exchange);
+
+    OAuth2AccessTokenResponse tokenResponse = stravaConfiguration
+        .stravaAccessTokenResponseClient().getTokenResponse(grantRequest);
+
+    OAuth2AuthorizedClient authorizedClient = new OAuth2AuthorizedClient(
+        registration, principalName, tokenResponse.getAccessToken(), tokenResponse.getRefreshToken());
+
+    Authentication auth = new PreAuthenticatedAuthenticationToken(principalName, null);
+    authorizedClientRepository.saveAuthorizedClient(authorizedClient, auth, request, response);
+
+    log.info("Successful Strava authorization for principal: {}", principalName);
     return new RedirectView("/");
+  }
+
+  private String buildRedirectUri(HttpServletRequest request) {
+    return ServletUriComponentsBuilder.fromRequest(request)
+        .replacePath(request.getContextPath() + "/strava/authorize")
+        .replaceQuery(null)
+        .build().toUriString();
   }
 
   private OAuth2AuthorizedClient getAuthorizedClient(Authentication principal, HttpServletRequest servletRequest,

--- a/server/src/main/java/mucsi96/traininglog/withings/WithingsConfiguration.java
+++ b/server/src/main/java/mucsi96/traininglog/withings/WithingsConfiguration.java
@@ -6,8 +6,10 @@ import java.util.Set;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -30,6 +32,7 @@ import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
 import org.springframework.security.oauth2.core.http.converter.OAuth2AccessTokenResponseHttpMessageConverter;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -53,14 +56,17 @@ public class WithingsConfiguration {
 
   @Bean
   @Order(2)
-  SecurityFilterChain withingsSecurityFilterChain(HttpSecurity http) throws Exception {
+  @Profile({"prod", "local"})
+  SecurityFilterChain withingsSecurityFilterChain(HttpSecurity http,
+      JwtAuthenticationConverter jwtAuthenticationConverter) throws Exception {
     return http
         .securityMatcher("/withings/**")
         .csrf(AbstractHttpConfigurer::disable)
-        .oauth2Client(configurer -> configurer
-            .authorizationCodeGrant(customizer -> customizer
-                .accessTokenResponseClient(withingsAccessTokenResponseClient())))
-        .authorizeHttpRequests(authorize -> authorize.anyRequest().authenticated())
+        .oauth2ResourceServer(oauth2 -> oauth2
+            .jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter)))
+        .authorizeHttpRequests(authorize -> authorize
+            .requestMatchers(HttpMethod.GET, "/withings/authorize").permitAll()
+            .anyRequest().authenticated())
         .build();
   }
 

--- a/server/src/main/java/mucsi96/traininglog/withings/WithingsController.java
+++ b/server/src/main/java/mucsi96/traininglog/withings/WithingsController.java
@@ -3,41 +3,67 @@ package mucsi96.traininglog.withings;
 import java.time.ZoneId;
 import java.util.Map;
 
+import org.springframework.core.env.Environment;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
 import org.springframework.security.oauth2.core.OAuth2AuthorizationException;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationExchange;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationResponse;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import org.springframework.web.servlet.view.RedirectView;
-
-import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import mucsi96.traininglog.core.AuthTokenService;
 import mucsi96.traininglog.weight.WeightService;
 
 @RestController
 @RequestMapping("/withings")
 @RequiredArgsConstructor
-@PreAuthorize("hasAuthority('APPROLE_WorkoutCreator') and hasAuthority('SCOPE_createWorkout')")
 @Slf4j
 public class WithingsController {
+
+  private static final String TEST_PRINCIPAL = "rob";
 
   private final WithingsService withingsService;
   private final WeightService weightService;
   private final OAuth2AuthorizedClientManager withingsAuthorizedClientManager;
+  private final AuthTokenService authTokenService;
+  private final ClientRegistrationRepository clientRegistrationRepository;
+  private final OAuth2AuthorizedClientRepository authorizedClientRepository;
+  private final WithingsConfiguration withingsConfiguration;
+  private final Environment environment;
+
+  @PostMapping("/auth-token")
+  @PreAuthorize("hasAuthority('APPROLE_WorkoutCreator') and hasAuthority('SCOPE_createWorkout')")
+  public Map<String, String> createAuthToken(Authentication principal) {
+    String token = authTokenService.generateToken(principal.getName());
+    return Map.of("token", token);
+  }
 
   @PostMapping("/sync")
+  @PreAuthorize("hasAuthority('APPROLE_WorkoutCreator') and hasAuthority('SCOPE_createWorkout')")
   public ResponseEntity<?> sync(
       Authentication principal,
       HttpServletRequest servletRequest,
@@ -51,7 +77,7 @@ public class WithingsController {
       withingsService.getTodayWeight(authorizedClient, zoneId).ifPresent(weightService::saveWeight);
     } catch (OAuth2AuthorizationException ex) {
       String authorizeUrl = ServletUriComponentsBuilder.fromRequestUri(servletRequest)
-          .replacePath("/withings/authorize").toUriString();
+          .replacePath(servletRequest.getContextPath() + "/withings/authorize").toUriString();
       return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
           .body(Map.of("_links", Map.of("oauth2Login", Map.of("href", authorizeUrl))));
     }
@@ -61,12 +87,98 @@ public class WithingsController {
 
   @GetMapping("/authorize")
   public RedirectView authorize(
-      Authentication principal,
+      @RequestParam(name = "auth_token", required = false) String authToken,
+      @RequestParam(name = "code", required = false) String code,
+      @RequestParam(name = "state", required = false) String state,
       HttpServletRequest servletRequest,
       HttpServletResponse servletResponse) {
-    log.info("authorizing Withings client");
-    getAuthorizedClient(principal, servletRequest, servletResponse);
+
+    if (code != null && state != null) {
+      return handleCallback(code, state, servletRequest, servletResponse);
+    }
+
+    String principalName = resolvePrincipalName(authToken);
+    return initiateAuthorization(principalName, servletRequest);
+  }
+
+  private String resolvePrincipalName(String authToken) {
+    if (authToken != null) {
+      String principalName = authTokenService.validateAndConsume(authToken);
+      if (principalName != null) {
+        return principalName;
+      }
+    }
+    if (environment.matchesProfiles("test")) {
+      return TEST_PRINCIPAL;
+    }
+    throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Invalid or expired auth token");
+  }
+
+  private RedirectView initiateAuthorization(String principalName, HttpServletRequest request) {
+    ClientRegistration registration = clientRegistrationRepository
+        .findByRegistrationId(WithingsConfiguration.registrationId);
+    String redirectUri = buildRedirectUri(request);
+    String stateValue = authTokenService.generateToken(principalName);
+
+    String authUrl = UriComponentsBuilder
+        .fromUriString(registration.getProviderDetails().getAuthorizationUri())
+        .queryParam("client_id", registration.getClientId())
+        .queryParam("redirect_uri", redirectUri)
+        .queryParam("response_type", "code")
+        .queryParam("scope", String.join(" ", registration.getScopes()))
+        .queryParam("state", stateValue)
+        .build().toUriString();
+
+    log.info("Redirecting to Withings authorization: {}", authUrl);
+    return new RedirectView(authUrl);
+  }
+
+  private RedirectView handleCallback(String code, String state,
+      HttpServletRequest request, HttpServletResponse response) {
+    String principalName = authTokenService.validateAndConsume(state);
+    if (principalName == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid or expired state");
+    }
+
+    ClientRegistration registration = clientRegistrationRepository
+        .findByRegistrationId(WithingsConfiguration.registrationId);
+    String redirectUri = buildRedirectUri(request);
+
+    OAuth2AuthorizationRequest authRequest = OAuth2AuthorizationRequest.authorizationCode()
+        .clientId(registration.getClientId())
+        .authorizationUri(registration.getProviderDetails().getAuthorizationUri())
+        .redirectUri(redirectUri)
+        .scopes(registration.getScopes())
+        .state(state)
+        .build();
+
+    OAuth2AuthorizationResponse authResponse = OAuth2AuthorizationResponse.success(code)
+        .redirectUri(redirectUri)
+        .state(state)
+        .build();
+
+    OAuth2AuthorizationExchange exchange = new OAuth2AuthorizationExchange(authRequest, authResponse);
+    var grantRequest = new org.springframework.security.oauth2.client.endpoint.OAuth2AuthorizationCodeGrantRequest(
+        registration, exchange);
+
+    OAuth2AccessTokenResponse tokenResponse = withingsConfiguration
+        .withingsAccessTokenResponseClient().getTokenResponse(grantRequest);
+
+    OAuth2AuthorizedClient authorizedClient = new OAuth2AuthorizedClient(
+        registration, principalName, tokenResponse.getAccessToken(), tokenResponse.getRefreshToken());
+
+    Authentication auth = new PreAuthenticatedAuthenticationToken(principalName, null);
+    authorizedClientRepository.saveAuthorizedClient(authorizedClient, auth, request, response);
+
+    log.info("Successful Withings authorization for principal: {}", principalName);
     return new RedirectView("/");
+  }
+
+  private String buildRedirectUri(HttpServletRequest request) {
+    return ServletUriComponentsBuilder.fromRequest(request)
+        .replacePath(request.getContextPath() + "/withings/authorize")
+        .replaceQuery(null)
+        .build().toUriString();
   }
 
   private OAuth2AuthorizedClient getAuthorizedClient(Authentication principal, HttpServletRequest servletRequest,

--- a/server/src/main/resources/application-test.yml
+++ b/server/src/main/resources/application-test.yml
@@ -12,8 +12,6 @@ spring:
         secret:
           property-sources:
             - enabled: false
-      active-directory:
-        enabled: false
   security:
     oauth2:
       client:

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -25,14 +25,12 @@ spring:
           property-sources:
             - endpoint: ${AZURE_KEYVAULT_ENDPOINT}
               enabled: true
-      active-directory:
-        enabled: true
-        profile:
-          tenant-id: ${tenant-id}
-        credential:
-          client-id: ${api-client-id}
   security:
     oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: https://login.microsoftonline.com/${tenant-id}/v2.0
+          audiences: ${api-client-id}
       client:
         provider:
           withings:


### PR DESCRIPTION
…T and temp auth tokens

- Remove spring-cloud-azure-starter-active-directory dependency
- Use standard oauth2ResourceServer JWT with custom JwtAuthenticationConverter for Azure AD claim mapping (roles -> APPROLE_*, scp -> SCOPE_*)
- Add JWT issuer-uri and audiences config for Azure AD v2.0 endpoint
- Implement AuthTokenService for short-lived, single-use in-memory tokens to protect Strava/Withings OAuth2 authorize endpoints
- Rework Strava/Withings controllers to handle the full OAuth2 authorization code flow manually (initiate redirect, exchange code for tokens)
- Add POST /auth-token endpoints protected by Azure AD JWT for the client to obtain temp tokens before navigating to authorize URLs
- Client detects 401 responses with _links.oauth2Login and triggers the auth-token + redirect flow (or direct redirect in test mode)
- Filter chains for Strava/Withings scoped to prod/local profiles; test profile uses single permit-all chain

https://claude.ai/code/session_01TtWVTRPvPpFRNpJYcCcD8x