### PR TITLE
Add one-time token bridge for OAuth2 authorization flow

### DIFF
--- a/client/src/app/strava/strava.service.spec.ts
+++ b/client/src/app/strava/strava.service.spec.ts
@@ -61,6 +61,41 @@ describe('StravaService', () => {
       );
     });
 
+    it('should request OTT and redirect on 401 with oauth2Login link', async () => {
+      const { service, httpTestingController, mockNotificationService } =
+        setup();
+
+      const originalHref = window.location.href;
+      spyOnProperty(window, 'location', 'get').and.returnValue({
+        ...window.location,
+        set href(value: string) {},
+        get href() {
+          return originalHref;
+        },
+      } as Location);
+
+      const promise = service.sync();
+      await Promise.resolve();
+      const syncRequest = httpTestingController.expectOne(
+        '/api/strava/activities/sync'
+      );
+      syncRequest.flush(
+        { _links: { oauth2Login: { href: '/api/strava/authorize' } } },
+        { status: 401, statusText: 'Unauthorized' }
+      );
+
+      await Promise.resolve();
+      const ottRequest = httpTestingController.expectOne(
+        '/api/token-bridge/generate'
+      );
+      expect(ottRequest.request.method).toBe('POST');
+      ottRequest.flush({ token: 'test-token' });
+
+      await promise;
+      httpTestingController.verify();
+      expect(mockNotificationService.showNotification).not.toHaveBeenCalled();
+    });
+
     it('caches last backup time', async () => {
       const { service, httpTestingController } = setup();
       const promise1 = service.sync();

--- a/client/src/app/strava/strava.service.ts
+++ b/client/src/app/strava/strava.service.ts
@@ -1,8 +1,9 @@
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { NotificationService } from '../common-components/notification.service';
 import { WithingsService } from '../withings/withings.service';
 import { fetchJson } from '../utils/fetchJson';
+import { requestOttAndRedirect } from '../utils/ott-bridge';
 
 @Injectable({ providedIn: 'root' })
 export class StravaService {
@@ -20,7 +21,12 @@ export class StravaService {
             method: 'post',
           })
         )
-        .catch(() => {
+        .catch((error: HttpErrorResponse) => {
+          const authorizeUrl = error.error?._links?.oauth2Login?.href;
+          if (error.status === 401 && authorizeUrl) {
+            requestOttAndRedirect(this.http, authorizeUrl);
+            return;
+          }
           this.notificationService.showNotification(
             'Unable to sync with Strava',
             'error'

--- a/client/src/app/utils/error.interceptor.ts
+++ b/client/src/app/utils/error.interceptor.ts
@@ -7,11 +7,13 @@ export const errorInterceptor: HttpInterceptorFn = (req, next) => {
   const snackBar = inject(MatSnackBar);
   return next(req).pipe(
     catchError((error) => {
-      snackBar.open('An error occurred. ' + error.message, 'Close', {
-        duration: 3000,
-        verticalPosition: 'top',
-        panelClass: ['error'],
-      });
+      if (error.status !== 401) {
+        snackBar.open('An error occurred. ' + error.message, 'Close', {
+          duration: 3000,
+          verticalPosition: 'top',
+          panelClass: ['error'],
+        });
+      }
 
       return Promise.reject(error);
     })

--- a/client/src/app/utils/ott-bridge.ts
+++ b/client/src/app/utils/ott-bridge.ts
@@ -1,0 +1,15 @@
+import { HttpClient } from '@angular/common/http';
+import { fetchJson } from './fetchJson';
+
+export async function requestOttAndRedirect(
+  http: HttpClient,
+  authorizeUrl: string
+): Promise<void> {
+  const { token } = await fetchJson<{ token: string }>(
+    http,
+    '/api/token-bridge/generate',
+    { method: 'post' }
+  );
+  const separator = authorizeUrl.includes('?') ? '&' : '?';
+  window.location.href = `${authorizeUrl}${separator}token=${token}`;
+}

--- a/client/src/app/withings/withings.service.spec.ts
+++ b/client/src/app/withings/withings.service.spec.ts
@@ -50,6 +50,42 @@ describe('WithingsService', () => {
       );
     });
 
+    it('should request OTT and redirect on 401 with oauth2Login link', async () => {
+      const { service, httpTestingController, mockNotificationService } =
+        setup();
+
+      const originalHref = window.location.href;
+      const hrefSetter = spyOnProperty(
+        window,
+        'location',
+        'get'
+      ).and.returnValue({
+        ...window.location,
+        set href(value: string) {},
+        get href() {
+          return originalHref;
+        },
+      } as Location);
+
+      const promise = service.sync();
+      const syncRequest = httpTestingController.expectOne('/api/withings/sync');
+      syncRequest.flush(
+        { _links: { oauth2Login: { href: '/api/withings/authorize' } } },
+        { status: 401, statusText: 'Unauthorized' }
+      );
+
+      await Promise.resolve();
+      const ottRequest = httpTestingController.expectOne(
+        '/api/token-bridge/generate'
+      );
+      expect(ottRequest.request.method).toBe('POST');
+      ottRequest.flush({ token: 'test-token' });
+
+      await promise;
+      httpTestingController.verify();
+      expect(mockNotificationService.showNotification).not.toHaveBeenCalled();
+    });
+
     it('caches last backup time', async () => {
       const { service, httpTestingController } = setup();
       const promise1 = service.sync();

--- a/client/src/app/withings/withings.service.ts
+++ b/client/src/app/withings/withings.service.ts
@@ -1,7 +1,8 @@
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { NotificationService } from '../common-components/notification.service';
 import { fetchJson } from '../utils/fetchJson';
+import { requestOttAndRedirect } from '../utils/ott-bridge';
 
 @Injectable({ providedIn: 'root' })
 export class WithingsService {
@@ -13,7 +14,12 @@ export class WithingsService {
     if (!this.syncPromise) {
       this.syncPromise = fetchJson<void>(this.http, '/api/withings/sync', {
         method: 'post',
-      }).catch(() => {
+      }).catch((error: HttpErrorResponse) => {
+        const authorizeUrl = error.error?._links?.oauth2Login?.href;
+        if (error.status === 401 && authorizeUrl) {
+          requestOttAndRedirect(this.http, authorizeUrl);
+          return;
+        }
         this.notificationService.showNotification(
           'Unable to sync with Withings',
           'error'

--- a/server/src/main/java/mucsi96/traininglog/core/OneTimeTokenBridgeConfiguration.java
+++ b/server/src/main/java/mucsi96/traininglog/core/OneTimeTokenBridgeConfiguration.java
@@ -1,0 +1,15 @@
+package mucsi96.traininglog.core;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.ott.InMemoryOneTimeTokenService;
+import org.springframework.security.authentication.ott.OneTimeTokenService;
+
+@Configuration
+public class OneTimeTokenBridgeConfiguration {
+
+  @Bean
+  OneTimeTokenService oneTimeTokenService() {
+    return new InMemoryOneTimeTokenService();
+  }
+}

--- a/server/src/main/java/mucsi96/traininglog/core/OneTimeTokenBridgeFilter.java
+++ b/server/src/main/java/mucsi96/traininglog/core/OneTimeTokenBridgeFilter.java
@@ -1,0 +1,46 @@
+package mucsi96.traininglog.core;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import org.springframework.security.authentication.ott.OneTimeToken;
+import org.springframework.security.authentication.ott.OneTimeTokenAuthenticationToken;
+import org.springframework.security.authentication.ott.OneTimeTokenService;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Slf4j
+public class OneTimeTokenBridgeFilter extends OncePerRequestFilter {
+
+  private final OneTimeTokenService oneTimeTokenService;
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+    String tokenValue = request.getParameter("token");
+
+    if (tokenValue != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+      try {
+        OneTimeTokenAuthenticationToken authRequest = new OneTimeTokenAuthenticationToken(tokenValue);
+        OneTimeToken token = oneTimeTokenService.consume(authRequest);
+        PreAuthenticatedAuthenticationToken authentication = new PreAuthenticatedAuthenticationToken(
+            token.getUsername(), null, Collections.emptyList());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        log.info("Successfully authenticated via one-time token for user: {}", token.getUsername());
+      } catch (Exception e) {
+        log.debug("One-time token authentication failed: {}", e.getMessage());
+      }
+    }
+
+    filterChain.doFilter(request, response);
+  }
+}

--- a/server/src/main/java/mucsi96/traininglog/core/TestSecurityConfiguration.java
+++ b/server/src/main/java/mucsi96/traininglog/core/TestSecurityConfiguration.java
@@ -17,6 +17,7 @@ public class TestSecurityConfiguration {
     public SecurityFilterChain testSecurityFilterChain(HttpSecurity http) throws Exception {
         http
             .csrf(AbstractHttpConfigurer::disable)
+            .anonymous(anonymous -> anonymous.principal("rob"))
             .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
         return http.build();
     }

--- a/server/src/main/java/mucsi96/traininglog/core/TokenBridgeController.java
+++ b/server/src/main/java/mucsi96/traininglog/core/TokenBridgeController.java
@@ -1,0 +1,28 @@
+package mucsi96.traininglog.core;
+
+import java.util.Map;
+
+import org.springframework.security.authentication.ott.GenerateOneTimeTokenRequest;
+import org.springframework.security.authentication.ott.OneTimeToken;
+import org.springframework.security.authentication.ott.OneTimeTokenService;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/token-bridge")
+@RequiredArgsConstructor
+public class TokenBridgeController {
+
+  private final OneTimeTokenService oneTimeTokenService;
+
+  @PostMapping("/generate")
+  public Map<String, String> generate(Authentication auth) {
+    GenerateOneTimeTokenRequest request = new GenerateOneTimeTokenRequest(auth.getName());
+    OneTimeToken token = oneTimeTokenService.generate(request);
+    return Map.of("token", token.getTokenValue());
+  }
+}

--- a/server/src/main/java/mucsi96/traininglog/strava/StravaConfiguration.java
+++ b/server/src/main/java/mucsi96/traininglog/strava/StravaConfiguration.java
@@ -27,10 +27,14 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
+import org.springframework.security.authentication.ott.OneTimeTokenService;
+import org.springframework.security.web.authentication.preauth.AbstractPreAuthenticatedProcessingFilter;
+
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
+import mucsi96.traininglog.core.OneTimeTokenBridgeFilter;
 
 @Data
 @Configuration
@@ -44,13 +48,16 @@ public class StravaConfiguration {
 
   @Bean
   @Order(1)
-  SecurityFilterChain stravaSecurityFilterChain(HttpSecurity http) throws Exception {
+  SecurityFilterChain stravaSecurityFilterChain(HttpSecurity http, OneTimeTokenService oneTimeTokenService)
+      throws Exception {
     return http
         .securityMatcher("/strava/**")
         .csrf(AbstractHttpConfigurer::disable)
+        .addFilterBefore(new OneTimeTokenBridgeFilter(oneTimeTokenService),
+            AbstractPreAuthenticatedProcessingFilter.class)
         .oauth2Client(configurer -> configurer
-        .authorizationCodeGrant(customizer -> customizer
-        .accessTokenResponseClient(stravaAccessTokenResponseClient())))
+            .authorizationCodeGrant(customizer -> customizer
+                .accessTokenResponseClient(stravaAccessTokenResponseClient())))
         .authorizeHttpRequests(authorize -> authorize.anyRequest().authenticated())
         .build();
   }

--- a/server/src/main/java/mucsi96/traininglog/strava/StravaController.java
+++ b/server/src/main/java/mucsi96/traininglog/strava/StravaController.java
@@ -29,7 +29,6 @@ import mucsi96.traininglog.rides.RideService;
 @RestController
 @RequestMapping("/strava")
 @RequiredArgsConstructor
-@PreAuthorize("hasAuthority('APPROLE_WorkoutCreator') and hasAuthority('SCOPE_createWorkout')")
 @Slf4j
 public class StravaController {
 
@@ -38,6 +37,7 @@ public class StravaController {
   private final OAuth2AuthorizedClientManager stravaAuthorizedClientManager;
 
   @PostMapping("/activities/sync")
+  @PreAuthorize("hasAuthority('APPROLE_WorkoutCreator') and hasAuthority('SCOPE_createWorkout')")
   public ResponseEntity<?> syncActivities(
       Authentication principal,
       HttpServletRequest servletRequest,
@@ -51,7 +51,7 @@ public class StravaController {
       stravaActivityService.getTodayRides(authorizedClient, zoneId).forEach(rideService::saveRide);
     } catch (OAuth2AuthorizationException ex) {
       String authorizeUrl = ServletUriComponentsBuilder.fromRequestUri(servletRequest)
-          .replacePath("/strava/authorize").toUriString();
+          .replacePath(servletRequest.getContextPath() + "/strava/authorize").toUriString();
       return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
           .body(Map.of("_links", Map.of("oauth2Login", Map.of("href", authorizeUrl))));
     }

--- a/server/src/main/java/mucsi96/traininglog/withings/WithingsConfiguration.java
+++ b/server/src/main/java/mucsi96/traininglog/withings/WithingsConfiguration.java
@@ -37,10 +37,14 @@ import org.springframework.web.client.RestClient;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.springframework.security.authentication.ott.OneTimeTokenService;
+import org.springframework.security.web.authentication.preauth.AbstractPreAuthenticatedProcessingFilter;
+
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
+import mucsi96.traininglog.core.OneTimeTokenBridgeFilter;
 
 @Data
 @Configuration
@@ -53,10 +57,13 @@ public class WithingsConfiguration {
 
   @Bean
   @Order(2)
-  SecurityFilterChain withingsSecurityFilterChain(HttpSecurity http) throws Exception {
+  SecurityFilterChain withingsSecurityFilterChain(HttpSecurity http, OneTimeTokenService oneTimeTokenService)
+      throws Exception {
     return http
         .securityMatcher("/withings/**")
         .csrf(AbstractHttpConfigurer::disable)
+        .addFilterBefore(new OneTimeTokenBridgeFilter(oneTimeTokenService),
+            AbstractPreAuthenticatedProcessingFilter.class)
         .oauth2Client(configurer -> configurer
             .authorizationCodeGrant(customizer -> customizer
                 .accessTokenResponseClient(withingsAccessTokenResponseClient())))

--- a/server/src/main/java/mucsi96/traininglog/withings/WithingsController.java
+++ b/server/src/main/java/mucsi96/traininglog/withings/WithingsController.java
@@ -29,7 +29,6 @@ import mucsi96.traininglog.weight.WeightService;
 @RestController
 @RequestMapping("/withings")
 @RequiredArgsConstructor
-@PreAuthorize("hasAuthority('APPROLE_WorkoutCreator') and hasAuthority('SCOPE_createWorkout')")
 @Slf4j
 public class WithingsController {
 
@@ -38,6 +37,7 @@ public class WithingsController {
   private final OAuth2AuthorizedClientManager withingsAuthorizedClientManager;
 
   @PostMapping("/sync")
+  @PreAuthorize("hasAuthority('APPROLE_WorkoutCreator') and hasAuthority('SCOPE_createWorkout')")
   public ResponseEntity<?> sync(
       Authentication principal,
       HttpServletRequest servletRequest,
@@ -51,7 +51,7 @@ public class WithingsController {
       withingsService.getTodayWeight(authorizedClient, zoneId).ifPresent(weightService::saveWeight);
     } catch (OAuth2AuthorizationException ex) {
       String authorizeUrl = ServletUriComponentsBuilder.fromRequestUri(servletRequest)
-          .replacePath("/withings/authorize").toUriString();
+          .replacePath(servletRequest.getContextPath() + "/withings/authorize").toUriString();
       return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
           .body(Map.of("_links", Map.of("oauth2Login", Map.of("href", authorizeUrl))));
     }


### PR DESCRIPTION
## Summary
Implement a one-time token (OTT) bridge mechanism to enable seamless OAuth2 authorization redirects without losing the current user session. This allows authenticated users to authorize third-party integrations (Strava, Withings) and return to their original context.

## Key Changes

**Backend:**
- Added `OneTimeTokenBridgeFilter` - A servlet filter that intercepts requests with a `token` query parameter and authenticates users via one-time tokens before OAuth2 processing
- Added `TokenBridgeController` - REST endpoint (`POST /api/token-bridge/generate`) that generates one-time tokens for authenticated users
- Added `OneTimeTokenBridgeConfiguration` - Spring configuration that provides an in-memory one-time token service
- Integrated the OTT filter into both Strava and Withings security filter chains, positioned before pre-authentication processing
- Moved `@PreAuthorize` annotations from class-level to method-level in `StravaController` and `WithingsController` to allow unauthenticated access to endpoints that will trigger OAuth2 flow

**Frontend:**
- Added `ott-bridge.ts` utility - Helper function `requestOttAndRedirect()` that requests a one-time token and redirects to the OAuth2 authorization URL with the token as a query parameter
- Updated `StravaService` and `WithingsService` - Enhanced error handling to detect 401 responses with OAuth2 login links and initiate the OTT bridge flow instead of showing error notifications
- Updated `error.interceptor.ts` - Suppressed error notifications for 401 responses to avoid duplicate notifications during OAuth2 redirects

## Implementation Details
- The OTT bridge enables a secure flow: authenticated user → request OTT → redirect to OAuth2 with token → filter consumes token and re-authenticates → OAuth2 flow proceeds
- Uses Spring Security's built-in `OneTimeTokenService` and `OneTimeTokenAuthenticationToken` for token generation and validation
- One-time tokens are consumed immediately after use, preventing replay attacks
- The solution maintains backward compatibility while adding optional OAuth2 authorization capability

https://claude.ai/code/session_01Xy7K62PoPQNZEZuXtqnT7y