### PR TITLE
Replace Azure AD Spring integration with standard OAuth2 JWT

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -64,10 +64,6 @@
       <artifactId>spring-boot-starter-security-oauth2-resource-server</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.azure.spring</groupId>
-      <artifactId>spring-cloud-azure-starter-active-directory</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-oauth2-client</artifactId>
     </dependency>

--- a/server/src/main/java/mucsi96/traininglog/core/SecurityConfiguration.java
+++ b/server/src/main/java/mucsi96/traininglog/core/SecurityConfiguration.java
@@ -1,15 +1,20 @@
 package mucsi96.traininglog.core;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.web.SecurityFilterChain;
-
-import com.azure.spring.cloud.autoconfigure.implementation.aad.security.AadResourceServerHttpSecurityConfigurer;
 
 @Profile({"prod", "local"})
 @Configuration
@@ -18,11 +23,9 @@ public class SecurityConfiguration {
 
     @Bean
     @Order(3)
-    SecurityFilterChain securityFilterChain(HttpSecurity http)
-            throws Exception {
-
-        http.with(AadResourceServerHttpSecurityConfigurer.aadResourceServer(),
-                Customizer.withDefaults());
+    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.oauth2ResourceServer(oauth2 -> oauth2
+                .jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter())));
 
         http.authorizeHttpRequests(requests -> requests
                 .requestMatchers("/environment").permitAll()
@@ -30,5 +33,30 @@ public class SecurityConfiguration {
                 .anyRequest().authenticated());
 
         return http.build();
+    }
+
+    private JwtAuthenticationConverter jwtAuthenticationConverter() {
+        JwtAuthenticationConverter converter = new JwtAuthenticationConverter();
+        converter.setJwtGrantedAuthoritiesConverter(jwt -> {
+            Collection<GrantedAuthority> authorities = new ArrayList<>();
+
+            List<String> roles = jwt.getClaimAsStringList("roles");
+            if (roles != null) {
+                roles.stream()
+                        .map(role -> new SimpleGrantedAuthority("APPROLE_" + role))
+                        .forEach(authorities::add);
+            }
+
+            String scp = jwt.getClaimAsString("scp");
+            if (scp != null) {
+                Arrays.stream(scp.split(" "))
+                        .filter(s -> !s.isEmpty())
+                        .map(scope -> new SimpleGrantedAuthority("SCOPE_" + scope))
+                        .forEach(authorities::add);
+            }
+
+            return authorities;
+        });
+        return converter;
     }
 }

--- a/server/src/main/resources/application-local.yml
+++ b/server/src/main/resources/application-local.yml
@@ -3,11 +3,6 @@ spring:
     url: jdbc:postgresql://localhost:5434/training_log
     username: postgres
     password: postgres
-  cloud:
-    azure:
-      active-directory:
-        credential:
-          client-secret: ${api-client-secret}
 management:
   server:
     port: 8182

--- a/server/src/main/resources/application-test.yml
+++ b/server/src/main/resources/application-test.yml
@@ -12,8 +12,6 @@ spring:
         secret:
           property-sources:
             - enabled: false
-      active-directory:
-        enabled: false
   security:
     oauth2:
       client:

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -25,14 +25,12 @@ spring:
           property-sources:
             - endpoint: ${AZURE_KEYVAULT_ENDPOINT}
               enabled: true
-      active-directory:
-        enabled: true
-        profile:
-          tenant-id: ${tenant-id}
-        credential:
-          client-id: ${api-client-id}
   security:
     oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: https://login.microsoftonline.com/${tenant-id}/v2.0
+          audiences: ${api-client-id}
       client:
         provider:
           withings:


### PR DESCRIPTION
## Summary
Migrated from Azure Spring Cloud's Active Directory starter to Spring Security's standard OAuth2 Resource Server with JWT support. This change removes the Azure-specific dependency and configuration in favor of a more portable, standards-based OAuth2 implementation.

## Key Changes
- **Removed Azure AD dependency**: Deleted `spring-cloud-azure-starter-active-directory` from pom.xml
- **Replaced security configuration**: Updated `SecurityConfiguration.java` to use `oauth2ResourceServer()` with JWT authentication instead of `AadResourceServerHttpSecurityConfigurer`
- **Implemented custom JWT converter**: Added `jwtAuthenticationConverter()` method that extracts authorities from JWT claims:
  - Maps `roles` claim to `APPROLE_` prefixed authorities
  - Maps `scp` (scope) claim to `SCOPE_` prefixed authorities
- **Updated OAuth2 configuration**: Modified `application.yml` to configure JWT resource server with:
  - `issuer-uri`: Microsoft login endpoint with tenant ID
  - `audiences`: API client ID for token validation
- **Cleaned up Azure-specific configs**: Removed `active-directory` configuration blocks from `application.yml`, `application-local.yml`, and `application-test.yml`

## Implementation Details
The custom `JwtAuthenticationConverter` handles authority extraction from JWT claims, supporting both role-based and scope-based authorization patterns. The implementation gracefully handles null claims and empty scopes to prevent errors during token processing.

https://claude.ai/code/session_016oK3NtXqDbcKiC1Zu5q8io