### PR TITLE
Replace Spring OTT with custom TokenService

### DIFF
--- a/server/src/main/java/mucsi96/traininglog/core/OneTimeTokenBridgeFilter.java
+++ b/server/src/main/java/mucsi96/traininglog/core/OneTimeTokenBridgeFilter.java
@@ -1,0 +1,42 @@
+package mucsi96.traininglog.core;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Slf4j
+public class OneTimeTokenBridgeFilter extends OncePerRequestFilter {
+
+  private final TokenService tokenService;
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+    String tokenValue = request.getParameter("token");
+
+    if (tokenValue != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+      try {
+        String username = tokenService.consume(tokenValue);
+        PreAuthenticatedAuthenticationToken authentication = new PreAuthenticatedAuthenticationToken(
+            username, null, Collections.emptyList());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        log.info("Successfully authenticated via token for user: {}", username);
+      } catch (Exception e) {
+        log.debug("Token authentication failed: {}", e.getMessage());
+      }
+    }
+
+    filterChain.doFilter(request, response);
+  }
+}

--- a/server/src/main/java/mucsi96/traininglog/strava/StravaConfiguration.java
+++ b/server/src/main/java/mucsi96/traininglog/strava/StravaConfiguration.java
@@ -27,10 +27,14 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
+import org.springframework.security.web.authentication.preauth.AbstractPreAuthenticatedProcessingFilter;
+
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
+import mucsi96.traininglog.core.OneTimeTokenBridgeFilter;
+import mucsi96.traininglog.core.TokenService;
 
 @Data
 @Configuration
@@ -44,15 +48,17 @@ public class StravaConfiguration {
 
   @Bean
   @Order(1)
-  SecurityFilterChain stravaSecurityFilterChain(HttpSecurity http)
+  SecurityFilterChain stravaSecurityFilterChain(HttpSecurity http, TokenService tokenService)
       throws Exception {
     return http
         .securityMatcher("/strava/authorize")
         .csrf(AbstractHttpConfigurer::disable)
+        .addFilterBefore(new OneTimeTokenBridgeFilter(tokenService),
+            AbstractPreAuthenticatedProcessingFilter.class)
         .oauth2Client(configurer -> configurer
             .authorizationCodeGrant(customizer -> customizer
                 .accessTokenResponseClient(stravaAccessTokenResponseClient())))
-        .authorizeHttpRequests(authorize -> authorize.anyRequest().permitAll())
+        .authorizeHttpRequests(authorize -> authorize.anyRequest().authenticated())
         .build();
   }
 

--- a/server/src/main/java/mucsi96/traininglog/strava/StravaController.java
+++ b/server/src/main/java/mucsi96/traininglog/strava/StravaController.java
@@ -1,24 +1,20 @@
 package mucsi96.traininglog.strava;
 
 import java.time.ZoneId;
-import java.util.Collections;
 import java.util.Map;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.core.OAuth2AuthorizationException;
-import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.view.RedirectView;
 
@@ -70,14 +66,10 @@ public class StravaController {
 
   @GetMapping("/authorize")
   public RedirectView authorize(
-      @RequestParam String token,
+      Authentication principal,
       HttpServletRequest servletRequest,
       HttpServletResponse servletResponse) {
     log.info("authorizing Strava client");
-    String username = tokenService.consume(token);
-    Authentication principal = new PreAuthenticatedAuthenticationToken(
-        username, null, Collections.emptyList());
-    SecurityContextHolder.getContext().setAuthentication(principal);
     getAuthorizedClient(principal, servletRequest, servletResponse);
     return new RedirectView("/");
   }

--- a/server/src/main/java/mucsi96/traininglog/withings/WithingsConfiguration.java
+++ b/server/src/main/java/mucsi96/traininglog/withings/WithingsConfiguration.java
@@ -37,10 +37,14 @@ import org.springframework.web.client.RestClient;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.springframework.security.web.authentication.preauth.AbstractPreAuthenticatedProcessingFilter;
+
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
+import mucsi96.traininglog.core.OneTimeTokenBridgeFilter;
+import mucsi96.traininglog.core.TokenService;
 
 @Data
 @Configuration
@@ -53,15 +57,17 @@ public class WithingsConfiguration {
 
   @Bean
   @Order(2)
-  SecurityFilterChain withingsSecurityFilterChain(HttpSecurity http)
+  SecurityFilterChain withingsSecurityFilterChain(HttpSecurity http, TokenService tokenService)
       throws Exception {
     return http
         .securityMatcher("/withings/authorize")
         .csrf(AbstractHttpConfigurer::disable)
+        .addFilterBefore(new OneTimeTokenBridgeFilter(tokenService),
+            AbstractPreAuthenticatedProcessingFilter.class)
         .oauth2Client(configurer -> configurer
             .authorizationCodeGrant(customizer -> customizer
                 .accessTokenResponseClient(withingsAccessTokenResponseClient())))
-        .authorizeHttpRequests(authorize -> authorize.anyRequest().permitAll())
+        .authorizeHttpRequests(authorize -> authorize.anyRequest().authenticated())
         .build();
   }
 

--- a/server/src/main/java/mucsi96/traininglog/withings/WithingsController.java
+++ b/server/src/main/java/mucsi96/traininglog/withings/WithingsController.java
@@ -1,24 +1,20 @@
 package mucsi96.traininglog.withings;
 
 import java.time.ZoneId;
-import java.util.Collections;
 import java.util.Map;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.core.OAuth2AuthorizationException;
-import org.springframework.security.web.authentication.preauth.PreAuthenticatedAuthenticationToken;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.view.RedirectView;
 
@@ -70,14 +66,10 @@ public class WithingsController {
 
   @GetMapping("/authorize")
   public RedirectView authorize(
-      @RequestParam String token,
+      Authentication principal,
       HttpServletRequest servletRequest,
       HttpServletResponse servletResponse) {
     log.info("authorizing Withings client");
-    String username = tokenService.consume(token);
-    Authentication principal = new PreAuthenticatedAuthenticationToken(
-        username, null, Collections.emptyList());
-    SecurityContextHolder.getContext().setAuthentication(principal);
     getAuthorizedClient(principal, servletRequest, servletResponse);
     return new RedirectView("/");
   }


### PR DESCRIPTION
## Summary
- Replace Spring's `InMemoryOneTimeTokenService` with a custom `TokenService` that allows up to 3 uses per token and expires after 1 minute
- Remove `OneTimeTokenBridgeConfiguration` (the Spring OTT bean); `TokenService` is a `@Service` and auto-scanned
- Update `OneTimeTokenBridgeFilter`, controllers, and security configurations to use `TokenService`

## Test plan
- [ ] Verify Strava OAuth2 authorization flow works (sync → 401 with token URL → authorize → callback → redirect)
- [ ] Verify Withings OAuth2 authorization flow works
- [ ] Verify tokens expire after 1 minute
- [ ] Verify tokens are rejected after 3 uses

https://claude.ai/code/session_0144TAsMAzJHh6hFWvcoWyr1