### PR TITLE
Add loading state and sync initialization on app startup

### DIFF
--- a/client/src/app/app.component.css
+++ b/client/src/app/app.component.css
@@ -8,10 +8,21 @@
     max-width: 90rem;
     margin: 0 auto;
     display: flex;
-    justify-content: space-between;
     align-items: center;
+    gap: 1rem;
     height: 100%;
   }
+}
+
+.brand {
+  font-weight: 500;
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin-left: auto;
 }
 
 .header-right {
@@ -25,4 +36,8 @@ main {
   padding: 1px max(1rem, env(safe-area-inset-right)) env(safe-area-inset-bottom) max(1rem, env(safe-area-inset-left));
   max-width: 90rem;
   margin: 50px auto 0;
+}
+
+.page-loading {
+  margin: 150px auto;
 }

--- a/client/src/app/app.component.html
+++ b/client/src/app/app.component.html
@@ -1,36 +1,38 @@
 <mat-toolbar class="header">
   <nav>
-    <a mat-button routerLink="">Training Log Pro</a>
-    @if (isAuthenticated()) {
-    <a
-      mat-button
-      routerLink=""
-      [routerLinkActiveOptions]="{ exact: true }"
-      routerLinkActive
-      ariaCurrentWhenActive="page"
-      >Week</a
-    >
-    <a
-      mat-button
-      routerLink="month"
-      routerLinkActive
-      ariaCurrentWhenActive="page"
-      >Month</a
-    >
-    <a
-      mat-button
-      routerLink="year"
-      routerLinkActive
-      ariaCurrentWhenActive="page"
-      >Year</a
-    >
-    <a
-      mat-button
-      routerLink="all-time"
-      routerLinkActive
-      ariaCurrentWhenActive="page"
-      >All time</a
-    >
+    <a class="brand" mat-button routerLink="">Training Log Pro</a>
+    @if (isAuthenticated() && isReady()) {
+    <div class="nav-links">
+      <a
+        mat-button
+        routerLink=""
+        [routerLinkActiveOptions]="{ exact: true }"
+        routerLinkActive
+        ariaCurrentWhenActive="page"
+        >Week</a
+      >
+      <a
+        mat-button
+        routerLink="month"
+        routerLinkActive
+        ariaCurrentWhenActive="page"
+        >Month</a
+      >
+      <a
+        mat-button
+        routerLink="year"
+        routerLinkActive
+        ariaCurrentWhenActive="page"
+        >Year</a
+      >
+      <a
+        mat-button
+        routerLink="all-time"
+        routerLinkActive
+        ariaCurrentWhenActive="page"
+        >All time</a
+      >
+    </div>
     <div class="header-right">
       <app-header></app-header>
     </div>
@@ -39,5 +41,9 @@
 </mat-toolbar>
 
 <main>
+  @if (isAuthenticated() && !isReady()) {
+  <mat-spinner class="page-loading" />
+  } @else {
   <router-outlet></router-outlet>
+  }
 </main>

--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -1,10 +1,13 @@
-import { Component, inject } from '@angular/core';
+import { Component, computed, effect, inject } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { HeaderComponent } from './header/header.component';
 import { AuthService } from './auth.service';
+import { StravaService } from './strava/strava.service';
+import { WithingsService } from './withings/withings.service';
 
 @Component({
   selector: 'app-root',
@@ -15,6 +18,7 @@ import { AuthService } from './auth.service';
     MatToolbarModule,
     MatButtonModule,
     MatTooltipModule,
+    MatProgressSpinnerModule,
     HeaderComponent,
   ],
   templateUrl: './app.component.html',
@@ -22,4 +26,18 @@ import { AuthService } from './auth.service';
 })
 export class AppComponent {
   readonly isAuthenticated = inject(AuthService).isAuthenticated;
+  private readonly stravaService = inject(StravaService);
+  private readonly withingsService = inject(WithingsService);
+
+  readonly isReady = computed(
+    () => this.stravaService.isSynced() && this.withingsService.isSynced()
+  );
+
+  constructor() {
+    effect(() => {
+      if (this.isAuthenticated()) {
+        this.stravaService.sync();
+      }
+    });
+  }
 }

--- a/client/src/app/strava/strava.service.ts
+++ b/client/src/app/strava/strava.service.ts
@@ -1,5 +1,5 @@
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
-import { inject, Injectable } from '@angular/core';
+import { inject, Injectable, signal } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { WithingsService } from '../withings/withings.service';
 import { fetchJson } from '../utils/fetchJson';
@@ -10,19 +10,21 @@ export class StravaService {
   private readonly snackBar = inject(MatSnackBar);
   private readonly withingsService = inject(WithingsService);
   private syncPromise: Promise<void> | undefined;
+  private readonly _isSynced = signal(false);
+  readonly isSynced = this._isSynced.asReadonly();
 
   sync(): Promise<void> {
     if (!this.syncPromise) {
-      this.syncPromise = this.withingsService
-        .sync()
-        .then(() =>
-          fetchJson<void>(this.http, '/api/strava/activities/sync', {
+      this.syncPromise = (async () => {
+        await this.withingsService.sync();
+        try {
+          await fetchJson<void>(this.http, '/api/strava/activities/sync', {
             method: 'post',
-          })
-        )
-        .catch((error: HttpErrorResponse) => {
-          const authorizeUrl = error.error?._links?.oauth2Login?.href;
-          if (error.status === 401 && authorizeUrl) {
+          });
+        } catch (error) {
+          const httpError = error as HttpErrorResponse;
+          const authorizeUrl = httpError.error?._links?.oauth2Login?.href;
+          if (httpError.status === 401 && authorizeUrl) {
             window.location.href = authorizeUrl;
             return;
           }
@@ -31,7 +33,9 @@ export class StravaService {
             verticalPosition: 'top',
             panelClass: ['error'],
           });
-        });
+        }
+        this._isSynced.set(true);
+      })();
     }
     return this.syncPromise;
   }

--- a/client/src/app/withings/withings.service.ts
+++ b/client/src/app/withings/withings.service.ts
@@ -1,5 +1,5 @@
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
-import { inject, Injectable } from '@angular/core';
+import { inject, Injectable, signal } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { fetchJson } from '../utils/fetchJson';
 
@@ -8,23 +8,31 @@ export class WithingsService {
   private readonly http = inject(HttpClient);
   private readonly snackBar = inject(MatSnackBar);
   private syncPromise: Promise<void> | undefined;
+  private readonly _isSynced = signal(false);
+  readonly isSynced = this._isSynced.asReadonly();
 
   sync(): Promise<void> {
     if (!this.syncPromise) {
-      this.syncPromise = fetchJson<void>(this.http, '/api/withings/sync', {
-        method: 'post',
-      }).catch((error: HttpErrorResponse) => {
-        const authorizeUrl = error.error?._links?.oauth2Login?.href;
-        if (error.status === 401 && authorizeUrl) {
-          window.location.href = authorizeUrl;
-          return;
+      this.syncPromise = (async () => {
+        try {
+          await fetchJson<void>(this.http, '/api/withings/sync', {
+            method: 'post',
+          });
+        } catch (error) {
+          const httpError = error as HttpErrorResponse;
+          const authorizeUrl = httpError.error?._links?.oauth2Login?.href;
+          if (httpError.status === 401 && authorizeUrl) {
+            window.location.href = authorizeUrl;
+            return;
+          }
+          this.snackBar.open('Unable to sync with Withings', 'Close', {
+            duration: 3000,
+            verticalPosition: 'top',
+            panelClass: ['error'],
+          });
         }
-        this.snackBar.open('Unable to sync with Withings', 'Close', {
-          duration: 3000,
-          verticalPosition: 'top',
-          panelClass: ['error'],
-        });
-      });
+        this._isSynced.set(true);
+      })();
     }
     return this.syncPromise;
   }


### PR DESCRIPTION
## Summary
This PR adds a loading state to the application that displays while syncing data from external services (Strava and Withings) on startup. The app now waits for both services to complete their initial sync before displaying the main content.

## Key Changes
- **Loading State Management**: Added `isSynced` signals to both `StravaService` and `WithingsService` to track completion of sync operations
- **App Initialization**: Implemented an effect in `AppComponent` that automatically triggers service sync when the user is authenticated
- **UI Feedback**: Added a loading spinner that displays in the main content area while services are syncing, with navigation links hidden until ready
- **Service Refactoring**: Converted promise chains in both services to async/await for improved readability and error handling
- **Layout Updates**: Reorganized header navigation with a new `.nav-links` container and improved spacing using flexbox gap

## Implementation Details
- The `isReady` computed signal in `AppComponent` combines both service sync states to determine when the app is fully initialized
- Navigation links are now conditionally rendered based on both authentication and readiness states
- Error handling in sync methods remains intact, with proper HTTP error casting in the async/await pattern
- The loading spinner is centered and positioned with appropriate margins for visual balance

https://claude.ai/code/session_014HbKnrsWoNDZcgY3HgTrfC