### PR TITLE
Prevent redirect loops and improve OAuth error handling

### DIFF
--- a/client/src/app/strava/strava.service.ts
+++ b/client/src/app/strava/strava.service.ts
@@ -4,6 +4,8 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { WithingsService } from '../withings/withings.service';
 import { fetchJson } from '../utils/fetchJson';
 
+const REDIRECT_GUARD_KEY = 'strava-authorize-redirected';
+
 @Injectable({ providedIn: 'root' })
 export class StravaService {
   private readonly http = inject(HttpClient);
@@ -21,18 +23,33 @@ export class StravaService {
           await fetchJson<void>(this.http, '/api/strava/activities/sync', {
             method: 'post',
           });
+          sessionStorage.removeItem(REDIRECT_GUARD_KEY);
         } catch (error) {
           const httpError = error as HttpErrorResponse;
           const authorizeUrl = httpError.error?._links?.oauth2Login?.href;
           if (httpError.status === 401 && authorizeUrl) {
-            window.location.href = authorizeUrl;
-            return;
+            if (sessionStorage.getItem(REDIRECT_GUARD_KEY)) {
+              this.snackBar.open(
+                'Unable to authorize Strava. Please try again later.',
+                'Close',
+                {
+                  duration: 5000,
+                  verticalPosition: 'top',
+                  panelClass: ['error'],
+                }
+              );
+            } else {
+              sessionStorage.setItem(REDIRECT_GUARD_KEY, '1');
+              window.location.href = authorizeUrl;
+              return;
+            }
+          } else {
+            this.snackBar.open('Unable to sync with Strava', 'Close', {
+              duration: 3000,
+              verticalPosition: 'top',
+              panelClass: ['error'],
+            });
           }
-          this.snackBar.open('Unable to sync with Strava', 'Close', {
-            duration: 3000,
-            verticalPosition: 'top',
-            panelClass: ['error'],
-          });
         }
         this._isSynced.set(true);
       })();

--- a/client/src/app/withings/withings.service.ts
+++ b/client/src/app/withings/withings.service.ts
@@ -3,6 +3,8 @@ import { inject, Injectable, signal } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { fetchJson } from '../utils/fetchJson';
 
+const REDIRECT_GUARD_KEY = 'withings-authorize-redirected';
+
 @Injectable({ providedIn: 'root' })
 export class WithingsService {
   private readonly http = inject(HttpClient);
@@ -18,18 +20,34 @@ export class WithingsService {
           await fetchJson<void>(this.http, '/api/withings/sync', {
             method: 'post',
           });
+          // Reset the guard on success so a later 401 can redirect once again.
+          sessionStorage.removeItem(REDIRECT_GUARD_KEY);
         } catch (error) {
           const httpError = error as HttpErrorResponse;
           const authorizeUrl = httpError.error?._links?.oauth2Login?.href;
           if (httpError.status === 401 && authorizeUrl) {
-            window.location.href = authorizeUrl;
-            return;
+            if (sessionStorage.getItem(REDIRECT_GUARD_KEY)) {
+              this.snackBar.open(
+                'Unable to authorize Withings. Please try again later.',
+                'Close',
+                {
+                  duration: 5000,
+                  verticalPosition: 'top',
+                  panelClass: ['error'],
+                }
+              );
+            } else {
+              sessionStorage.setItem(REDIRECT_GUARD_KEY, '1');
+              window.location.href = authorizeUrl;
+              return;
+            }
+          } else {
+            this.snackBar.open('Unable to sync with Withings', 'Close', {
+              duration: 3000,
+              verticalPosition: 'top',
+              panelClass: ['error'],
+            });
           }
-          this.snackBar.open('Unable to sync with Withings', 'Close', {
-            duration: 3000,
-            verticalPosition: 'top',
-            panelClass: ['error'],
-          });
         }
         this._isSynced.set(true);
       })();

--- a/server/src/main/java/mucsi96/traininglog/core/SecurityConfiguration.java
+++ b/server/src/main/java/mucsi96/traininglog/core/SecurityConfiguration.java
@@ -51,10 +51,10 @@ public class SecurityConfiguration {
                             .flatMap(Collection::stream)
                             .map(role -> (GrantedAuthority) new SimpleGrantedAuthority("APPROLE_" + role)))
                     .toList();
-            // Prefer `email`; fall back to `preferred_username` so tokens without
-            // the email optional claim still produce a stable, human-readable principal.
-            String principal = Optional.ofNullable(jwt.getClaimAsString("email"))
-                    .orElseGet(() -> jwt.getClaimAsString("preferred_username"));
+            // `oid` is the user's tenant-wide stable UUID in Azure AD v2.0 tokens.
+            // Fall back to `sub` so test tokens (which don't carry `oid`) still work.
+            String principal = Optional.ofNullable(jwt.getClaimAsString("oid"))
+                    .orElseGet(() -> jwt.getClaimAsString("sub"));
             return new JwtAuthenticationToken(jwt, authorities, principal);
         };
     }

--- a/server/src/main/java/mucsi96/traininglog/core/SecurityConfiguration.java
+++ b/server/src/main/java/mucsi96/traininglog/core/SecurityConfiguration.java
@@ -51,11 +51,7 @@ public class SecurityConfiguration {
                             .flatMap(Collection::stream)
                             .map(role -> (GrantedAuthority) new SimpleGrantedAuthority("APPROLE_" + role)))
                     .toList();
-            // `oid` is the user's tenant-wide stable UUID in Azure AD v2.0 tokens.
-            // Fall back to `sub` so test tokens (which don't carry `oid`) still work.
-            String principal = Optional.ofNullable(jwt.getClaimAsString("oid"))
-                    .orElseGet(() -> jwt.getClaimAsString("sub"));
-            return new JwtAuthenticationToken(jwt, authorities, principal);
+            return new JwtAuthenticationToken(jwt, authorities, jwt.getClaimAsString("oid"));
         };
     }
 }

--- a/server/src/main/java/mucsi96/traininglog/core/SecurityConfiguration.java
+++ b/server/src/main/java/mucsi96/traininglog/core/SecurityConfiguration.java
@@ -1,16 +1,21 @@
 package mucsi96.traininglog.core;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.Converter;
 
+import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
 import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
 import org.springframework.security.web.SecurityFilterChain;
 
@@ -35,17 +40,22 @@ public class SecurityConfiguration {
         return http.build();
     }
 
-    private JwtAuthenticationConverter jwtAuthenticationConverter() {
+    private Converter<Jwt, AbstractAuthenticationToken> jwtAuthenticationConverter() {
         JwtGrantedAuthoritiesConverter scopeConverter = new JwtGrantedAuthoritiesConverter();
 
-        JwtAuthenticationConverter converter = new JwtAuthenticationConverter();
-        converter.setJwtGrantedAuthoritiesConverter(jwt -> Stream.concat(
-                scopeConverter.convert(jwt).stream(),
-                Optional.ofNullable(jwt.getClaimAsStringList("roles"))
-                        .stream()
-                        .flatMap(Collection::stream)
-                        .map(role -> new SimpleGrantedAuthority("APPROLE_" + role)))
-                .toList());
-        return converter;
+        return jwt -> {
+            List<GrantedAuthority> authorities = Stream.concat(
+                    scopeConverter.convert(jwt).stream(),
+                    Optional.ofNullable(jwt.getClaimAsStringList("roles"))
+                            .stream()
+                            .flatMap(Collection::stream)
+                            .map(role -> (GrantedAuthority) new SimpleGrantedAuthority("APPROLE_" + role)))
+                    .toList();
+            // Prefer `email`; fall back to `preferred_username` so tokens without
+            // the email optional claim still produce a stable, human-readable principal.
+            String principal = Optional.ofNullable(jwt.getClaimAsString("email"))
+                    .orElseGet(() -> jwt.getClaimAsString("preferred_username"));
+            return new JwtAuthenticationToken(jwt, authorities, principal);
+        };
     }
 }

--- a/server/src/main/java/mucsi96/traininglog/withings/WithingsConfiguration.java
+++ b/server/src/main/java/mucsi96/traininglog/withings/WithingsConfiguration.java
@@ -28,6 +28,8 @@ import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizedCli
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2AuthorizationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
@@ -189,7 +191,8 @@ public class WithingsConfiguration {
 
       if (response.getStatus() != 0) {
         log.error(response.getError());
-        throw new RuntimeException(response.getError());
+        throw new OAuth2AuthorizationException(
+            new OAuth2Error(OAuth2ErrorCodes.INVALID_GRANT, response.getError(), null));
       }
 
       WithingsGetAccessTokenResponseBody body = response.getBody();

--- a/test/test-pod.yaml
+++ b/test/test-pod.yaml
@@ -82,6 +82,8 @@ spec:
           value: default
         - name: SUB
           value: test-user
+        - name: OID
+          value: 00000000-0000-0000-0000-000000000001
         - name: NAME
           value: Test User
         - name: PREFERRED_USERNAME

--- a/test/tests/strava.spec.ts
+++ b/test/tests/strava.spec.ts
@@ -26,7 +26,7 @@ test.describe('Strava', () => {
     await page.waitForURL('/');
 
     const client = await getOAuthClient('strava-client');
-    expect(client.principal_name).toBe('test-user@example.com');
+    expect(client.principal_name).toBe('test-user');
   });
 
   test('should pull today\'s ride stats from strava', async ({ page }) => {

--- a/test/tests/strava.spec.ts
+++ b/test/tests/strava.spec.ts
@@ -26,7 +26,7 @@ test.describe('Strava', () => {
     await page.waitForURL('/');
 
     const client = await getOAuthClient('strava-client');
-    expect(client.principal_name).toBe('test-user');
+    expect(client.principal_name).toBe('00000000-0000-0000-0000-000000000001');
   });
 
   test('should pull today\'s ride stats from strava', async ({ page }) => {

--- a/test/tests/strava.spec.ts
+++ b/test/tests/strava.spec.ts
@@ -26,7 +26,7 @@ test.describe('Strava', () => {
     await page.waitForURL('/');
 
     const client = await getOAuthClient('strava-client');
-    expect(client.principal_name).toBe('test-user');
+    expect(client.principal_name).toBe('test-user@example.com');
   });
 
   test('should pull today\'s ride stats from strava', async ({ page }) => {

--- a/test/tests/withings.spec.ts
+++ b/test/tests/withings.spec.ts
@@ -13,7 +13,7 @@ test.describe('Withings', () => {
     await page.waitForURL('/');
 
     const client = await getOAuthClient('withings-client');
-    expect(client.principal_name).toBe('test-user');
+    expect(client.principal_name).toBe('test-user@example.com');
   });
 
   test('should pull today\'s weight measurements from withings', async ({ page }) => {

--- a/test/tests/withings.spec.ts
+++ b/test/tests/withings.spec.ts
@@ -13,7 +13,7 @@ test.describe('Withings', () => {
     await page.waitForURL('/');
 
     const client = await getOAuthClient('withings-client');
-    expect(client.principal_name).toBe('test-user@example.com');
+    expect(client.principal_name).toBe('test-user');
   });
 
   test('should pull today\'s weight measurements from withings', async ({ page }) => {

--- a/test/tests/withings.spec.ts
+++ b/test/tests/withings.spec.ts
@@ -13,7 +13,7 @@ test.describe('Withings', () => {
     await page.waitForURL('/');
 
     const client = await getOAuthClient('withings-client');
-    expect(client.principal_name).toBe('test-user');
+    expect(client.principal_name).toBe('00000000-0000-0000-0000-000000000001');
   });
 
   test('should pull today\'s weight measurements from withings', async ({ page }) => {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -36,7 +36,7 @@ export async function populateOAuthClients() {
       access_token_scopes, refresh_token_value, refresh_token_issued_at, created_at
     ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
     [
-      'withings-client', 'test-user', 'Bearer',
+      'withings-client', '00000000-0000-0000-0000-000000000001', 'Bearer',
       Buffer.from('test-access-token'), now, tomorrow,
       'user.metrics', Buffer.from('test-refresh-token'), now, now,
     ]
@@ -49,7 +49,7 @@ export async function populateOAuthClients() {
       access_token_scopes, refresh_token_value, refresh_token_issued_at, created_at
     ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
     [
-      'strava-client', 'test-user', 'Bearer',
+      'strava-client', '00000000-0000-0000-0000-000000000001', 'Bearer',
       Buffer.from('test-access-token'), now, tomorrow,
       'activity:read', Buffer.from('test-refresh-token'), now, now,
     ]

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -36,7 +36,7 @@ export async function populateOAuthClients() {
       access_token_scopes, refresh_token_value, refresh_token_issued_at, created_at
     ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
     [
-      'withings-client', 'test-user@example.com', 'Bearer',
+      'withings-client', 'test-user', 'Bearer',
       Buffer.from('test-access-token'), now, tomorrow,
       'user.metrics', Buffer.from('test-refresh-token'), now, now,
     ]
@@ -49,7 +49,7 @@ export async function populateOAuthClients() {
       access_token_scopes, refresh_token_value, refresh_token_issued_at, created_at
     ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
     [
-      'strava-client', 'test-user@example.com', 'Bearer',
+      'strava-client', 'test-user', 'Bearer',
       Buffer.from('test-access-token'), now, tomorrow,
       'activity:read', Buffer.from('test-refresh-token'), now, now,
     ]

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -36,7 +36,7 @@ export async function populateOAuthClients() {
       access_token_scopes, refresh_token_value, refresh_token_issued_at, created_at
     ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
     [
-      'withings-client', 'test-user', 'Bearer',
+      'withings-client', 'test-user@example.com', 'Bearer',
       Buffer.from('test-access-token'), now, tomorrow,
       'user.metrics', Buffer.from('test-refresh-token'), now, now,
     ]
@@ -49,7 +49,7 @@ export async function populateOAuthClients() {
       access_token_scopes, refresh_token_value, refresh_token_issued_at, created_at
     ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
     [
-      'strava-client', 'test-user', 'Bearer',
+      'strava-client', 'test-user@example.com', 'Bearer',
       Buffer.from('test-access-token'), now, tomorrow,
       'activity:read', Buffer.from('test-refresh-token'), now, now,
     ]


### PR DESCRIPTION
## Summary
This PR improves OAuth authorization flow reliability by preventing redirect loops when authorization fails, enhances error messaging for users, and refactors JWT authentication handling on the backend.

## Key Changes

### Client-side (Angular)
- **Redirect guard mechanism**: Added `sessionStorage`-based guard to prevent infinite redirect loops when OAuth authorization fails
  - On successful sync, the guard is cleared to allow future authorization attempts
  - On 401 with authorization URL, check if already redirected; if so, show error message instead of redirecting again
  - Applied to both Withings and Strava services with service-specific error messages

- **Improved error handling**: Separated error messages based on error type
  - Authorization failures show: "Unable to authorize [Service]. Please try again later."
  - Other sync failures show: "Unable to sync with [Service]"

### Server-side (Java/Spring Security)
- **JWT authentication refactoring**: Replaced deprecated `JwtAuthenticationConverter` with custom `Converter<Jwt, AbstractAuthenticationToken>` implementation
  - Maintains existing authority mapping (scopes + roles with "APPROLE_" prefix)
  - Sets principal name to `oid` claim instead of default behavior for better user identification

- **OAuth error handling**: Changed Withings token response error handling to throw `OAuth2AuthorizationException` instead of generic `RuntimeException` for proper Spring Security error processing

### Test Updates
- Updated test fixtures to use UUID (`00000000-0000-0000-0000-000000000001`) as principal name instead of string `test-user`
- Updated test assertions to match new principal name format
- Added `OID` environment variable to test pod configuration

## Notable Implementation Details
- The redirect guard uses a simple flag in `sessionStorage` to track if a redirect has already been attempted in the current session
- The guard is automatically cleared on successful sync, allowing the user to authorize again if needed later
- The JWT authentication converter now explicitly sets the principal name to the `oid` claim, which is typically the Azure AD object ID in OAuth2 flows

https://claude.ai/code/session_01BNNwAqwAH8qXvWXKaMy9Bc