### PR TITLE
Make pushup daily goal configurable via settings

### DIFF
--- a/client/src/app/pushups/pushups.component.html
+++ b/client/src/app/pushups/pushups.component.html
@@ -1,5 +1,5 @@
 @let chart = chartOptions();
-@if (todaySets.isLoading()) {
+@if (todaySets.isLoading() || goldenDayGoal.isLoading()) {
 <mat-spinner class="page-loading" />
 } @else {
 <section aria-labelledby="pushups-heading">
@@ -15,7 +15,7 @@
   </header>
 
   <div class="ring-wrapper" role="img"
-       [attr.aria-label]="todayCount() + ' of ' + goal + ' pushups today'">
+       [attr.aria-label]="todayCount() + ' of ' + goal() + ' pushups today'">
     <svg class="ring" viewBox="0 0 120 120" aria-hidden="true">
       <circle class="ring-track" cx="60" cy="60" r="52" />
       <circle
@@ -29,7 +29,7 @@
     </svg>
     <div class="ring-content">
       <span class="ring-count">{{ todayCount() }}</span>
-      <span class="ring-goal">/ {{ goal }}</span>
+      <span class="ring-goal">/ {{ goal() }}</span>
     </div>
   </div>
 

--- a/client/src/app/pushups/pushups.component.ts
+++ b/client/src/app/pushups/pushups.component.ts
@@ -7,8 +7,8 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { map } from 'rxjs';
 import { PushupsService } from './pushups.service';
+import { SettingsService } from '../settings/settings.service';
 
-const DAILY_GOAL = 100;
 const QUICK_ADD_VALUES = [-5, 5, 10] as const;
 
 @Component({
@@ -24,14 +24,21 @@ const QUICK_ADD_VALUES = [-5, 5, 10] as const;
 })
 export class PushupsComponent {
   private readonly pushupsService = inject(PushupsService);
+  private readonly settingsService = inject(SettingsService);
   private readonly period = toSignal(
     inject(ActivatedRoute).data.pipe(map((data) => (data['period'] as number) ?? 0))
   );
 
   readonly initOpts = { renderer: 'svg' as const };
-  readonly goal = DAILY_GOAL;
   readonly quickAddValues = QUICK_ADD_VALUES;
   readonly busy = signal(false);
+
+  readonly goldenDayGoal = resource({
+    params: () => this.settingsService.version(),
+    loader: () => this.settingsService.getGoldenDayGoal(),
+  });
+
+  readonly goal = computed(() => this.goldenDayGoal.value()?.pushupGoal ?? 0);
 
   readonly todaySets = resource({
     params: () => this.pushupsService.version(),
@@ -47,13 +54,14 @@ export class PushupsComponent {
     () => this.todaySets.value()?.reduce((total, set) => total + set.count, 0) ?? 0
   );
 
-  readonly progressPercent = computed(() =>
-    Math.min(100, (this.todayCount() / this.goal) * 100)
-  );
+  readonly progressPercent = computed(() => {
+    const goal = this.goal();
+    return goal > 0 ? Math.min(100, (this.todayCount() / goal) * 100) : 0;
+  });
 
-  readonly remaining = computed(() => Math.max(0, this.goal - this.todayCount()));
+  readonly remaining = computed(() => Math.max(0, this.goal() - this.todayCount()));
 
-  readonly goalReached = computed(() => this.todayCount() >= this.goal);
+  readonly goalReached = computed(() => this.goal() > 0 && this.todayCount() >= this.goal());
 
   readonly chartOptions = computed<EChartsOption | undefined>(() => {
     const sets = this.periodSets.value();
@@ -88,7 +96,7 @@ export class PushupsComponent {
             symbol: 'none',
             label: { show: false },
             lineStyle: { color: 'hsl(218, 11%, 65%)', type: 'dashed' },
-            data: [{ yAxis: this.goal }],
+            data: [{ yAxis: this.goal() }],
           },
         },
       ],

--- a/test/tests/pushups.spec.ts
+++ b/test/tests/pushups.spec.ts
@@ -4,6 +4,7 @@ import {
   populateOAuthClients,
   insertPushupSet,
   getPushupSetRows,
+  setGoldenDayGoal,
 } from '../utils';
 
 const startOfTodayUtc = () => {
@@ -88,6 +89,32 @@ test.describe('Pushups', () => {
 
     await expect(
       section.getByRole('img', { name: '100 of 100 pushups today' })
+    ).toBeVisible();
+    await expect(section.getByText('Daily goal reached')).toBeVisible();
+  });
+
+  test('reflects the configured golden day pushup goal', async ({ page }) => {
+    await setGoldenDayGoal(50, 250);
+    await insertPushupSet(daysAgoAt(0, 8), 20);
+
+    await page.goto('/');
+
+    const section = page.getByRole('region', { name: 'Pushups' });
+    await expect(
+      section.getByRole('img', { name: '20 of 50 pushups today' })
+    ).toBeVisible();
+    await expect(section.getByText('30 to go')).toBeVisible();
+  });
+
+  test('marks the daily goal reached when totals match the configured goal', async ({ page }) => {
+    await setGoldenDayGoal(40, 250);
+    await insertPushupSet(daysAgoAt(0, 8), 40);
+
+    await page.goto('/');
+
+    const section = page.getByRole('region', { name: 'Pushups' });
+    await expect(
+      section.getByRole('img', { name: '40 of 40 pushups today' })
     ).toBeVisible();
     await expect(section.getByText('Daily goal reached')).toBeVisible();
   });


### PR DESCRIPTION
## Summary
This PR makes the pushup daily goal configurable through the settings service instead of being hardcoded to 100 pushups. The goal is now fetched dynamically and used throughout the pushups component.

## Key Changes
- **Removed hardcoded daily goal**: Replaced the constant `DAILY_GOAL = 100` with a dynamic value fetched from settings
- **Integrated SettingsService**: Injected `SettingsService` into `PushupsComponent` to retrieve the configured golden day pushup goal
- **Converted goal to computed signal**: Changed `goal` from a static property to a computed signal that derives its value from `goldenDayGoal` resource
- **Updated all goal references**: Modified all usages of `this.goal` to `this.goal()` throughout the component to account for the signal-based approach
- **Added loading state**: Updated the template to wait for both `todaySets` and `goldenDayGoal` resources to finish loading before rendering
- **Added safety checks**: Enhanced computed properties (`progressPercent` and `goalReached`) to handle cases where the goal might be 0 or undefined
- **Added test coverage**: Included two new test cases that verify the component correctly reflects the configured golden day pushup goal and marks the daily goal as reached when totals match

## Notable Implementation Details
- The `goldenDayGoal` resource uses `settingsService.version()` as a parameter to ensure it reloads when settings change
- The `goal` computed signal safely defaults to 0 if the resource hasn't loaded yet
- Progress percentage calculation now guards against division by zero
- The goal reached condition now requires both a positive goal and the count to meet or exceed it

https://claude.ai/code/session_01Pc3LMDhAU742mEHnMtEc4E