### PR TITLE
Add podium achievement feature for segment efforts

### DIFF
--- a/client/src/app/ride/ride.component.css
+++ b/client/src/app/ride/ride.component.css
@@ -36,3 +36,30 @@ h2 {
 .page-loading {
   margin: 150px auto;
 }
+
+.podium-banner {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 16px 20px;
+  margin: 0 0 24px;
+  border-radius: 12px;
+  background: var(--mat-sys-primary-container, #00415a);
+  color: var(--mat-sys-on-primary-container, #d6f0ff);
+  box-shadow: 0 1px 3px rgb(0 0 0 / 0.2);
+}
+
+.podium-banner mat-icon {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  font-size: 32px;
+  color: var(--mat-sys-tertiary, #f5c518);
+}
+
+.podium-banner .podium-title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1.3;
+}

--- a/client/src/app/ride/ride.component.html
+++ b/client/src/app/ride/ride.component.html
@@ -1,8 +1,22 @@
 @let today = todayRideStats.value();
 @let period = periodRideStats.value();
+@let podium = podiumMessage.value();
 @if (todayRideStats.isLoading() || periodRideStats.isLoading()) {
 <mat-spinner class="page-loading" />
 } @else if (today && period) {
+@if (podium) {
+<aside
+  class="podium-banner"
+  data-testid="podium-banner"
+  [attr.data-period]="podium.period"
+  [attr.data-position]="podium.position"
+>
+  <mat-icon aria-hidden="true">emoji_events</mat-icon>
+  <div class="podium-text">
+    <p class="podium-title">{{ podium.message }}</p>
+  </div>
+</aside>
+}
 <section>
   <article>
     <h2>Calories</h2>

--- a/client/src/app/ride/ride.component.ts
+++ b/client/src/app/ride/ride.component.ts
@@ -1,6 +1,7 @@
 import { Component, inject, resource } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
+import { MatIconModule } from '@angular/material/icon';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { map } from 'rxjs';
 import { RideService } from './ride.service';
@@ -8,7 +9,7 @@ import { MeasurementWithUnitPipe } from '../utils/measurement-with-unit.pipe';
 
 @Component({
   standalone: true,
-  imports: [MatProgressSpinnerModule, MeasurementWithUnitPipe],
+  imports: [MatIconModule, MatProgressSpinnerModule, MeasurementWithUnitPipe],
   selector: 'app-ride',
   templateUrl: './ride.component.html',
   styleUrl: './ride.component.css',
@@ -26,5 +27,9 @@ export class RideComponent {
   readonly periodRideStats = resource({
     params: () => this.period(),
     loader: ({ params: period }) => this.rideService.getRideStats(period),
+  });
+
+  readonly podiumMessage = resource({
+    loader: () => this.rideService.getPodiumMessage(),
   });
 }

--- a/client/src/app/ride/ride.service.ts
+++ b/client/src/app/ride/ride.service.ts
@@ -1,5 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { StravaService } from '../strava/strava.service';
 import { fetchJson } from '../utils/fetchJson';
@@ -11,12 +12,22 @@ export type RideStats = {
   time?: number;
 };
 
+export type PodiumPeriod = 'WEEK' | 'MONTH' | 'ALL_TIME';
+
+export type PodiumMessage = {
+  segmentName: string;
+  period: PodiumPeriod;
+  position: number;
+  message: string;
+};
+
 @Injectable({ providedIn: 'root' })
 export class RideService {
   private readonly http = inject(HttpClient);
   private readonly stravaService = inject(StravaService);
   private readonly snackBar = inject(MatSnackBar);
   private readonly cache = new Map<number, RideStats>();
+  private podiumPromise: Promise<PodiumMessage | undefined> | undefined;
 
   async getRideStats(period = 0): Promise<RideStats> {
     const cached = this.cache.get(period);
@@ -38,5 +49,26 @@ export class RideService {
       });
       throw e;
     }
+  }
+
+  async getPodiumMessage(): Promise<PodiumMessage | undefined> {
+    if (this.podiumPromise) {
+      return this.podiumPromise;
+    }
+    this.podiumPromise = (async () => {
+      await this.stravaService.sync();
+      try {
+        const response = await firstValueFrom(
+          this.http.get<PodiumMessage>('/api/ride/podium', { observe: 'response' })
+        );
+        if (response.status === 204) {
+          return undefined;
+        }
+        return response.body ?? undefined;
+      } catch {
+        return undefined;
+      }
+    })();
+    return this.podiumPromise;
   }
 }

--- a/mock_strava_server/src/activities.ts
+++ b/mock_strava_server/src/activities.ts
@@ -1,5 +1,14 @@
 import { Request, Response } from 'express';
 
+type PushedSegmentEffort = {
+  id: number;
+  segmentId: number;
+  segmentName: string;
+  segmentDistance: number;
+  segmentAverageGrade: number;
+  elapsedTime: number;
+};
+
 type PushedActivity = {
   id: number;
   totalElevationGain: number;
@@ -11,6 +20,7 @@ type PushedActivity = {
   weightedAverageWatts: number;
   name: string;
   sportType: string;
+  segmentEfforts: PushedSegmentEffort[];
 };
 
 const DEFAULT_SUFFER_SCORES = [82, 162];
@@ -22,6 +32,17 @@ const startDateById = new Map<number, string>();
 export function pushActivity(req: Request, res: Response) {
   const body = req.body ?? {};
   const id = nextId++;
+  const segmentEfforts: PushedSegmentEffort[] = (body.segmentEfforts ?? []).map(
+    (effort: Partial<PushedSegmentEffort>, index: number) => ({
+      id: effort.id ?? id * 1000 + index,
+      segmentId: effort.segmentId ?? index + 1,
+      segmentName: effort.segmentName ?? `Segment ${index + 1}`,
+      segmentDistance: effort.segmentDistance ?? 500,
+      segmentAverageGrade: effort.segmentAverageGrade ?? 4,
+      elapsedTime: effort.elapsedTime ?? 120,
+    })
+  );
+
   const activity: PushedActivity = {
     id,
     totalElevationGain: body.totalElevationGain ?? 516,
@@ -36,6 +57,7 @@ export function pushActivity(req: Request, res: Response) {
     weightedAverageWatts: body.weightedAverageWatts ?? 230,
     name: body.name ?? `Test activity ${id}`,
     sportType: body.sportType ?? 'MountainBikeRide',
+    segmentEfforts,
   };
   activities.push(activity);
   console.log('[pushActivity] Stored activity', activity);
@@ -242,6 +264,41 @@ export function getActivity(req: Request, res: Response) {
     embed_token: 'embed-token',
     segment_leaderboard_opt_out: false,
     leaderboard_opt_out: false,
+    segment_efforts: activity.segmentEfforts.map((effort, index) => {
+      const effortStart = new Date(startDate);
+      effortStart.setUTCMinutes(effortStart.getUTCMinutes() + index);
+      return {
+        id: effort.id,
+        resource_state: 2,
+        name: effort.segmentName,
+        elapsed_time: effort.elapsedTime,
+        moving_time: effort.elapsedTime,
+        start_date: effortStart.toISOString(),
+        start_date_local: effortStart.toISOString(),
+        distance: effort.segmentDistance,
+        segment: {
+          id: effort.segmentId,
+          resource_state: 2,
+          name: effort.segmentName,
+          activity_type: 'Ride',
+          distance: effort.segmentDistance,
+          average_grade: effort.segmentAverageGrade,
+          maximum_grade: effort.segmentAverageGrade + 2,
+          elevation_high: 200,
+          elevation_low: 100,
+          climb_category: 0,
+          city: null,
+          state: null,
+          country: null,
+          private: false,
+          hazardous: false,
+          starred: false,
+        },
+        kom_rank: null,
+        pr_rank: null,
+        achievements: [],
+      };
+    }),
   };
 
   console.log(`[getActivity] Returning activity ${id} with start_date: ${startDate}`);

--- a/server/src/main/java/mucsi96/traininglog/rides/RideController.java
+++ b/server/src/main/java/mucsi96/traininglog/rides/RideController.java
@@ -4,6 +4,7 @@ import java.time.ZoneId;
 import java.util.Optional;
 
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,7 +15,9 @@ import org.springframework.security.access.prepost.PreAuthorize;
 
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
+import mucsi96.traininglog.api.PodiumMessage;
 import mucsi96.traininglog.api.RideStats;
+import mucsi96.traininglog.segments.PodiumService;
 
 @RestController
 @RequestMapping(value = "/ride", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -23,11 +26,19 @@ import mucsi96.traininglog.api.RideStats;
 public class RideController {
 
   private final RideService rideService;
+  private final PodiumService podiumService;
 
   @GetMapping("/stats")
   RideStats activity(
       @RequestParam(required = false) @Positive Integer period,
       @RequestHeader("X-Timezone") ZoneId zoneId) {
     return rideService.getStats(Optional.ofNullable(period), zoneId);
+  }
+
+  @GetMapping("/podium")
+  ResponseEntity<PodiumMessage> podium(@RequestHeader("X-Timezone") ZoneId zoneId) {
+    return podiumService.getTodayPodium(zoneId)
+        .map(message -> ResponseEntity.ok(message))
+        .orElseGet(() -> ResponseEntity.noContent().<PodiumMessage>build());
   }
 }

--- a/server/src/main/java/mucsi96/traininglog/segments/PodiumService.java
+++ b/server/src/main/java/mucsi96/traininglog/segments/PodiumService.java
@@ -1,0 +1,118 @@
+package mucsi96.traininglog.segments;
+
+import java.time.Clock;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import mucsi96.traininglog.api.PodiumMessage;
+import mucsi96.traininglog.api.PodiumMessage.PeriodEnum;
+
+@Service
+@RequiredArgsConstructor
+public class PodiumService {
+  private static final int PODIUM_SIZE = 3;
+
+  private final SegmentEffortRepository segmentEffortRepository;
+  private final Clock clock;
+
+  public Optional<PodiumMessage> getTodayPodium(ZoneId zoneId) {
+    ZonedDateTime startOfToday = ZonedDateTime.now(clock).withZoneSameInstant(zoneId).truncatedTo(ChronoUnit.DAYS);
+    ZonedDateTime endOfToday = startOfToday.plusDays(1);
+
+    List<SegmentEffort> todayEfforts = segmentEffortRepository
+        .findByStartDateBetween(startOfToday, endOfToday, Sort.by(Sort.Direction.ASC, "startDate"));
+
+    return todayEfforts.stream()
+        .flatMap(effort -> evaluatePodiumPlacements(effort, zoneId).stream())
+        .max(Comparator.comparingDouble(this::score))
+        .map(this::toMessage);
+  }
+
+  private List<PodiumPlacement> evaluatePodiumPlacements(SegmentEffort effort, ZoneId zoneId) {
+    ZonedDateTime startOfWeek = ZonedDateTime.now(clock).withZoneSameInstant(zoneId)
+        .truncatedTo(ChronoUnit.DAYS).minusDays(6);
+    ZonedDateTime startOfMonth = ZonedDateTime.now(clock).withZoneSameInstant(zoneId)
+        .truncatedTo(ChronoUnit.DAYS).minusDays(29);
+
+    List<SegmentEffort> allTime = segmentEffortRepository
+        .findBySegmentId(effort.getSegmentId(), Sort.by(Sort.Direction.ASC, "elapsedTime"));
+    List<SegmentEffort> month = segmentEffortRepository
+        .findBySegmentIdAndStartDateGreaterThanEqual(effort.getSegmentId(), startOfMonth,
+            Sort.by(Sort.Direction.ASC, "elapsedTime"));
+    List<SegmentEffort> week = segmentEffortRepository
+        .findBySegmentIdAndStartDateGreaterThanEqual(effort.getSegmentId(), startOfWeek,
+            Sort.by(Sort.Direction.ASC, "elapsedTime"));
+
+    return List.of(PeriodEnum.WEEK, PeriodEnum.MONTH, PeriodEnum.ALL_TIME).stream()
+        .map(period -> placementFor(effort, period, switch (period) {
+          case WEEK -> week;
+          case MONTH -> month;
+          case ALL_TIME -> allTime;
+        }))
+        .flatMap(Optional::stream)
+        .toList();
+  }
+
+  private Optional<PodiumPlacement> placementFor(SegmentEffort effort, PeriodEnum period,
+      List<SegmentEffort> rankedEfforts) {
+    if (rankedEfforts.size() < PODIUM_SIZE) {
+      return Optional.empty();
+    }
+    int position = 1;
+    for (SegmentEffort ranked : rankedEfforts) {
+      if (ranked.getId() == effort.getId()) {
+        if (position <= PODIUM_SIZE) {
+          return Optional.of(new PodiumPlacement(effort, period, position));
+        }
+        return Optional.empty();
+      }
+      position++;
+    }
+    return Optional.empty();
+  }
+
+  private double score(PodiumPlacement placement) {
+    double positionScore = PODIUM_SIZE + 1 - placement.position();
+    double periodScore = switch (placement.period()) {
+      case ALL_TIME -> 3;
+      case MONTH -> 2;
+      case WEEK -> 1;
+    };
+    double difficulty = Math.max(placement.effort().getSegmentDistance(), 1)
+        * Math.max(placement.effort().getSegmentAverageGrade(), 0.1);
+    return positionScore * periodScore * difficulty;
+  }
+
+  private PodiumMessage toMessage(PodiumPlacement placement) {
+    String periodLabel = switch (placement.period()) {
+      case ALL_TIME -> "all-time";
+      case MONTH -> "this month";
+      case WEEK -> "this week";
+    };
+    String podiumLabel = switch (placement.position()) {
+      case 1 -> "1st place";
+      case 2 -> "2nd place";
+      case 3 -> "3rd place";
+      default -> placement.position() + "th place";
+    };
+    String message = String.format("%s %s on %s",
+        podiumLabel, periodLabel, placement.effort().getSegmentName());
+    return PodiumMessage.builder()
+        .segmentName(placement.effort().getSegmentName())
+        .period(placement.period())
+        .position(placement.position())
+        .message(message)
+        .build();
+  }
+
+  private record PodiumPlacement(SegmentEffort effort, PeriodEnum period, int position) {
+  }
+}

--- a/server/src/main/java/mucsi96/traininglog/segments/SegmentEffort.java
+++ b/server/src/main/java/mucsi96/traininglog/segments/SegmentEffort.java
@@ -1,0 +1,44 @@
+package mucsi96.traininglog.segments;
+
+import java.time.ZonedDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Entity
+@Table(schema = "training_log")
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class SegmentEffort {
+  @Id
+  private long id;
+
+  @Column
+  private long segmentId;
+
+  @Column
+  private String segmentName;
+
+  @Column
+  private float segmentDistance;
+
+  @Column
+  private float segmentAverageGrade;
+
+  @Column
+  private int elapsedTime;
+
+  @Column
+  private ZonedDateTime startDate;
+
+  @Column
+  private ZonedDateTime rideCreatedAt;
+}

--- a/server/src/main/java/mucsi96/traininglog/segments/SegmentEffortRepository.java
+++ b/server/src/main/java/mucsi96/traininglog/segments/SegmentEffortRepository.java
@@ -1,0 +1,15 @@
+package mucsi96.traininglog.segments;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SegmentEffortRepository extends JpaRepository<SegmentEffort, Long> {
+  List<SegmentEffort> findByStartDateBetween(ZonedDateTime startTime, ZonedDateTime endTime, Sort sort);
+
+  List<SegmentEffort> findBySegmentIdAndStartDateGreaterThanEqual(long segmentId, ZonedDateTime startTime, Sort sort);
+
+  List<SegmentEffort> findBySegmentId(long segmentId, Sort sort);
+}

--- a/server/src/main/java/mucsi96/traininglog/segments/SegmentEffortService.java
+++ b/server/src/main/java/mucsi96/traininglog/segments/SegmentEffortService.java
@@ -1,0 +1,23 @@
+package mucsi96.traininglog.segments;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SegmentEffortService {
+  private final SegmentEffortRepository segmentEffortRepository;
+
+  public void saveAll(List<SegmentEffort> efforts) {
+    if (efforts.isEmpty()) {
+      return;
+    }
+    log.info("persisting {} segment efforts", efforts.size());
+    segmentEffortRepository.saveAll(efforts);
+  }
+}

--- a/server/src/main/java/mucsi96/traininglog/strava/StravaActivityService.java
+++ b/server/src/main/java/mucsi96/traininglog/strava/StravaActivityService.java
@@ -5,7 +5,9 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
@@ -26,6 +28,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import mucsi96.traininglog.rides.Ride;
+import mucsi96.traininglog.segments.SegmentEffort;
 import mucsi96.traininglog.strava.StravaSummaryActivity.SportTypeEnum;
 
 @Service
@@ -86,8 +89,11 @@ public class StravaActivityService {
     return activities.stream().filter((activity) -> rideActivities.contains(activity.getSportType())).toList();
   }
 
-  public List<Ride> getTodayRides(OAuth2AuthorizedClient authorizedClient, ZoneId zoneId) {
-    return getTodayRideActivities(authorizedClient, zoneId).stream().map(summary -> {
+  public StravaSyncResult getTodayRides(OAuth2AuthorizedClient authorizedClient, ZoneId zoneId) {
+    List<Ride> rides = new ArrayList<>();
+    List<SegmentEffort> segmentEfforts = new ArrayList<>();
+
+    getTodayRideActivities(authorizedClient, zoneId).forEach(summary -> {
       log.info("Getting Strava activity with id" + summary.getId());
       HttpHeaders headers = new HttpHeaders();
       headers.setBearerAuth(authorizedClient.getAccessToken().getTokenValue());
@@ -119,9 +125,10 @@ public class StravaActivityService {
       }
 
       Float sufferScore = activity.getSufferScore() != null ? activity.getSufferScore() : summary.getSufferScore();
+      ZonedDateTime rideCreatedAt = activity.getStartDate().atZoneSameInstant(ZoneOffset.UTC);
 
-      return Ride.builder()
-          .createdAt(activity.getStartDate().atZoneSameInstant(ZoneOffset.UTC))
+      rides.add(Ride.builder()
+          .createdAt(rideCreatedAt)
           .name(activity.getName())
           .movingTime(activity.getMovingTime())
           .distance(activity.getDistance())
@@ -130,8 +137,30 @@ public class StravaActivityService {
           .calories(activity.getCalories())
           .sportType(activity.getSportType())
           .sufferScore(sufferScore)
-          .build();
-    }).toList();
+          .build());
+
+      Optional.ofNullable(activity.getSegmentEfforts())
+          .orElse(List.of())
+          .stream()
+          .map(effort -> toSegmentEffort(effort, rideCreatedAt))
+          .forEach(segmentEfforts::add);
+    });
+
+    return StravaSyncResult.builder().rides(rides).segmentEfforts(segmentEfforts).build();
+  }
+
+  private SegmentEffort toSegmentEffort(StravaSegmentEffort effort, ZonedDateTime rideCreatedAt) {
+    StravaSegment segment = effort.getSegment();
+    return SegmentEffort.builder()
+        .id(effort.getId())
+        .segmentId(segment.getId())
+        .segmentName(segment.getName())
+        .segmentDistance(segment.getDistance())
+        .segmentAverageGrade(segment.getAverageGrade())
+        .elapsedTime(effort.getElapsedTime())
+        .startDate(effort.getStartDate().atZoneSameInstant(ZoneOffset.UTC))
+        .rideCreatedAt(rideCreatedAt)
+        .build();
   }
 
 }

--- a/server/src/main/java/mucsi96/traininglog/strava/StravaController.java
+++ b/server/src/main/java/mucsi96/traininglog/strava/StravaController.java
@@ -1,7 +1,6 @@
 package mucsi96.traininglog.strava;
 
 import java.time.ZoneId;
-import java.util.List;
 import java.util.Map;
 
 import org.springframework.http.HttpStatus;
@@ -27,8 +26,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import mucsi96.traininglog.core.TokenService;
 import mucsi96.traininglog.fitness.FitnessService;
-import mucsi96.traininglog.rides.Ride;
 import mucsi96.traininglog.rides.RideService;
+import mucsi96.traininglog.segments.SegmentEffortService;
 
 @RestController
 @RequestMapping("/strava")
@@ -38,6 +37,7 @@ public class StravaController {
 
   private final StravaActivityService stravaActivityService;
   private final RideService rideService;
+  private final SegmentEffortService segmentEffortService;
   private final FitnessService fitnessService;
   private final OAuth2AuthorizedClientManager stravaAuthorizedClientManager;
   private final TokenService tokenService;
@@ -54,8 +54,9 @@ public class StravaController {
 
     try {
       OAuth2AuthorizedClient authorizedClient = getAuthorizedClient(principal, servletRequest, servletResponse);
-      List<Ride> todayRides = stravaActivityService.getTodayRides(authorizedClient, zoneId);
-      todayRides.forEach(rideService::saveRide);
+      StravaSyncResult syncResult = stravaActivityService.getTodayRides(authorizedClient, zoneId);
+      syncResult.getRides().forEach(rideService::saveRide);
+      segmentEffortService.saveAll(syncResult.getSegmentEfforts());
       fitnessService.recomputeIfNeeded(zoneId);
     } catch (OAuth2AuthorizationException ex) {
       String token = tokenService.generate(principal.getName());

--- a/server/src/main/java/mucsi96/traininglog/strava/StravaSyncResult.java
+++ b/server/src/main/java/mucsi96/traininglog/strava/StravaSyncResult.java
@@ -1,0 +1,15 @@
+package mucsi96.traininglog.strava;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Data;
+import mucsi96.traininglog.rides.Ride;
+import mucsi96.traininglog.segments.SegmentEffort;
+
+@Data
+@Builder
+public class StravaSyncResult {
+  private final List<Ride> rides;
+  private final List<SegmentEffort> segmentEfforts;
+}

--- a/server/src/main/resources/api.yml
+++ b/server/src/main/resources/api.yml
@@ -61,6 +61,18 @@ paths:
                     type: integer
                     format: int64
 
+  /ride/podium:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PodiumMessage'
+        '204':
+          description: No podium achievement today
+
   /pushups:
     get:
       parameters:
@@ -240,3 +252,26 @@ components:
           format: int32
           minimum: 1
           maximum: 100000
+    PodiumMessage:
+      type: object
+      required:
+        - segmentName
+        - period
+        - position
+        - message
+      properties:
+        segmentName:
+          type: string
+        period:
+          type: string
+          enum:
+            - WEEK
+            - MONTH
+            - ALL_TIME
+        position:
+          type: integer
+          format: int32
+          minimum: 1
+          maximum: 3
+        message:
+          type: string

--- a/server/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/server/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -294,3 +294,64 @@ databaseChangeLog:
               ) elevation_by_day USING (day)
               WHERE pushups >= 100 AND elevation >= 250
               ON CONFLICT DO NOTHING;
+
+  - changeSet:
+      id: 10-create-segment-effort-table
+      author: mucsi96
+      changes:
+        - createTable:
+            tableName: segment_effort
+            columns:
+              - column:
+                  name: id
+                  type: bigint
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: segment_id
+                  type: bigint
+                  constraints:
+                    nullable: false
+              - column:
+                  name: segment_name
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: segment_distance
+                  type: float4
+                  constraints:
+                    nullable: false
+              - column:
+                  name: segment_average_grade
+                  type: float4
+                  constraints:
+                    nullable: false
+              - column:
+                  name: elapsed_time
+                  type: integer
+                  constraints:
+                    nullable: false
+              - column:
+                  name: start_date
+                  type: timestamp(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: ride_created_at
+                  type: timestamp(6)
+                  constraints:
+                    nullable: false
+        - createIndex:
+            tableName: segment_effort
+            indexName: idx_segment_effort_segment_id
+            columns:
+              - column:
+                  name: segment_id
+        - createIndex:
+            tableName: segment_effort
+            indexName: idx_segment_effort_start_date
+            columns:
+              - column:
+                  name: start_date

--- a/server/src/main/resources/strava.yml
+++ b/server/src/main/resources/strava.yml
@@ -278,3 +278,37 @@ paths:
                     type: string
                   embed_token:
                     type: string
+                  segment_efforts:
+                    type: array
+                    items:
+                      title: StravaSegmentEffort
+                      type: object
+                      properties:
+                        id:
+                          type: integer
+                          format: int64
+                        elapsed_time:
+                          type: integer
+                        moving_time:
+                          type: integer
+                        start_date:
+                          type: string
+                          format: date-time
+                        distance:
+                          type: number
+                          format: float
+                        segment:
+                          title: StravaSegment
+                          type: object
+                          properties:
+                            id:
+                              type: integer
+                              format: int64
+                            name:
+                              type: string
+                            distance:
+                              type: number
+                              format: float
+                            average_grade:
+                              type: number
+                              format: float

--- a/test/tests/podium.spec.ts
+++ b/test/tests/podium.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from '../fixtures';
+import {
+  cleanupDb,
+  getSegmentEffortRows,
+  insertSegmentEffort,
+  populateOAuthClients,
+  pushStravaActivity,
+} from '../utils';
+
+test.describe('Podium messages', () => {
+  test.beforeEach(async () => {
+    await cleanupDb();
+    await populateOAuthClients();
+  });
+
+  test('shows the best podium message above ride stats', async ({ page }) => {
+    // Two segments: one easy (Flat Loop), one hard (Steep Hill)
+    // Three historical efforts on each so the user has a "podium" to enter.
+    // Today's effort on Steep Hill is the new fastest of the week, which
+    // should outrank a 1st place all-time on the easier Flat Loop because
+    // Steep Hill is harder.
+    for (const daysAgo of [3, 4, 5]) {
+      await insertSegmentEffort({
+        id: 1000 + daysAgo,
+        segmentId: 1,
+        segmentName: 'Flat Loop',
+        segmentDistance: 1000,
+        segmentAverageGrade: 1,
+        elapsedTime: 200,
+        daysAgo,
+      });
+      await insertSegmentEffort({
+        id: 2000 + daysAgo,
+        segmentId: 2,
+        segmentName: 'Steep Hill',
+        segmentDistance: 800,
+        segmentAverageGrade: 10,
+        elapsedTime: 300,
+        daysAgo,
+      });
+    }
+
+    // Today's ride: a fastest-ever on Flat Loop AND a fastest-of-week on Steep Hill.
+    await pushStravaActivity({
+      segmentEfforts: [
+        {
+          id: 9001,
+          segmentId: 1,
+          segmentName: 'Flat Loop',
+          segmentDistance: 1000,
+          segmentAverageGrade: 1,
+          elapsedTime: 100,
+        },
+        {
+          id: 9002,
+          segmentId: 2,
+          segmentName: 'Steep Hill',
+          segmentDistance: 800,
+          segmentAverageGrade: 10,
+          elapsedTime: 250,
+        },
+      ],
+    });
+
+    await page.goto('/');
+
+    // Sync persisted both segment efforts from the synced activity.
+    await expect(page.getByRole('heading', { name: 'Calories' })).toBeVisible();
+    const efforts = await getSegmentEffortRows();
+    expect(efforts.map((row) => Number(row.id))).toEqual(
+      expect.arrayContaining([9001, 9002])
+    );
+
+    // The harder Steep Hill effort wins the single banner, even though
+    // the Flat Loop effort earned a higher (1st all-time) placement.
+    const banner = page.getByTestId('podium-banner');
+    await expect(banner).toBeVisible();
+    await expect(banner).toContainText('Steep Hill');
+    await expect(banner).not.toContainText('Flat Loop');
+  });
+
+  test('shows nothing when no podium was reached today', async ({ page }) => {
+    await pushStravaActivity({ segmentEfforts: [] });
+
+    await page.goto('/');
+    await expect(page.getByRole('heading', { name: 'Calories' })).toBeVisible();
+    await expect(page.getByTestId('podium-banner')).toHaveCount(0);
+  });
+});

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -19,6 +19,7 @@ export async function query(text: string, params?: any[]) {
 
 export async function cleanupDb() {
   await query('DELETE FROM training_log.weight');
+  await query('DELETE FROM training_log.segment_effort');
   await query('DELETE FROM training_log.ride');
   await query('DELETE FROM training_log.fitness');
   await query('DELETE FROM training_log.pushup_set');
@@ -130,6 +131,44 @@ export async function getRideRows() {
   return result.rows;
 }
 
+export async function insertSegmentEffort(
+  effort: {
+    id: number;
+    segmentId: number;
+    segmentName: string;
+    segmentDistance: number;
+    segmentAverageGrade: number;
+    elapsedTime: number;
+    daysAgo: number;
+  }
+) {
+  const startDate = new Date(Date.now() - effort.daysAgo * 86400000);
+  await query(
+    `INSERT INTO training_log.segment_effort (
+      id, segment_id, segment_name, segment_distance, segment_average_grade,
+      elapsed_time, start_date, ride_created_at
+    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $7)`,
+    [
+      effort.id,
+      effort.segmentId,
+      effort.segmentName,
+      effort.segmentDistance,
+      effort.segmentAverageGrade,
+      effort.elapsedTime,
+      startDate,
+    ]
+  );
+}
+
+export async function getSegmentEffortRows() {
+  const result = await query(
+    `SELECT id, segment_id, segment_name, segment_distance, segment_average_grade,
+            elapsed_time, start_date
+     FROM training_log.segment_effort ORDER BY id ASC`
+  );
+  return result.rows;
+}
+
 export async function getFitnessRows() {
   const result = await query(
     'SELECT created_at, pulled_at, fitness, fatigue, form FROM training_log.fitness ORDER BY created_at ASC'
@@ -180,6 +219,15 @@ export async function getOAuthClient(clientRegistrationId: string) {
   return result.rows[0];
 }
 
+export type PushStravaSegmentEffortOptions = {
+  id?: number;
+  segmentId?: number;
+  segmentName?: string;
+  segmentDistance?: number;
+  segmentAverageGrade?: number;
+  elapsedTime?: number;
+};
+
 export type PushStravaActivityOptions = {
   totalElevationGain?: number;
   sufferScore?: number | null;
@@ -190,6 +238,7 @@ export type PushStravaActivityOptions = {
   weightedAverageWatts?: number;
   name?: string;
   sportType?: string;
+  segmentEfforts?: PushStravaSegmentEffortOptions[];
 };
 
 export async function pushStravaActivity(options: PushStravaActivityOptions = {}) {


### PR DESCRIPTION
## Summary
This PR adds a "podium" achievement feature that displays a banner when a user achieves a top-3 placement on a segment during their ride. The system tracks segment efforts, evaluates placements across different time periods (week, month, all-time), and displays the most impressive achievement based on a scoring algorithm that considers placement, time period, and segment difficulty.

## Key Changes

**Backend:**
- Created `SegmentEffort` entity and `SegmentEffortRepository` to persist segment effort data from Strava activities
- Implemented `PodiumService` that:
  - Evaluates today's segment efforts against historical data
  - Calculates placements across three time periods (week, month, all-time)
  - Scores placements using a formula: `position_score × period_weight × segment_difficulty`
  - Returns the highest-scoring podium achievement as a `PodiumMessage`
- Created `SegmentEffortService` to handle persistence of segment efforts
- Modified `StravaActivityService` to extract segment efforts from Strava activities and return them via new `StravaSyncResult` wrapper
- Added `/ride/podium` GET endpoint that returns a `PodiumMessage` or 204 No Content
- Updated Strava API schema to include segment effort details

**Frontend:**
- Added `PodiumMessage` type and `getPodiumMessage()` method to `RideService`
- Updated `RideComponent` to fetch and display podium banner with trophy icon
- Added styling for the podium banner with Material Design theming
- Banner displays the achievement message (e.g., "1st place this week on Steep Hill")

**Database:**
- Created `segment_effort` table with columns for segment metadata, elapsed time, and timestamps
- Added indexes on `segment_id` and `start_date` for query performance

**Testing:**
- Added comprehensive test suite validating:
  - Podium banner displays the best achievement based on difficulty scoring
  - No banner appears when no podium is reached
  - Segment efforts are properly persisted from Strava activities

## Notable Implementation Details
- The scoring algorithm prioritizes harder segments (distance × grade) over easier ones, so a 1st place on a steep hill outranks a 1st place on a flat loop
- Only displays podium achievements when at least 3 historical efforts exist for a segment
- Supports timezone-aware date calculations for accurate "today" and "this week/month" boundaries
- Mock Strava server enhanced to support segment effort data in activity responses

https://claude.ai/code/session_01HDUpwsokbGdYED36P9BQeu