### PR TITLE
Replace early returns with never-resolving promises in auth flows

### DIFF
--- a/client/src/app/strava/strava.service.ts
+++ b/client/src/app/strava/strava.service.ts
@@ -3,6 +3,7 @@ import { inject, Injectable, signal } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { WithingsService } from '../withings/withings.service';
 import { fetchJson } from '../utils/fetchJson';
+import { haltForNavigation } from '../utils/auth';
 
 const REDIRECT_GUARD_KEY = 'strava-authorize-redirected';
 
@@ -41,7 +42,10 @@ export class StravaService {
             } else {
               sessionStorage.setItem(REDIRECT_GUARD_KEY, '1');
               window.location.href = authorizeUrl;
-              await new Promise<never>(() => {});
+              // Keep this promise pending so the sync flow does not continue
+              // after assigning window.location.href, preventing a competing
+              // redirect from being scheduled before the browser navigates.
+              await haltForNavigation();
             }
           } else {
             this.snackBar.open('Unable to sync with Strava', 'Close', {

--- a/client/src/app/strava/strava.service.ts
+++ b/client/src/app/strava/strava.service.ts
@@ -41,7 +41,7 @@ export class StravaService {
             } else {
               sessionStorage.setItem(REDIRECT_GUARD_KEY, '1');
               window.location.href = authorizeUrl;
-              return;
+              await new Promise<never>(() => {});
             }
           } else {
             this.snackBar.open('Unable to sync with Strava', 'Close', {

--- a/client/src/app/utils/auth.ts
+++ b/client/src/app/utils/auth.ts
@@ -1,0 +1,6 @@
+// Returns a promise that never resolves. Use it to freeze an async flow
+// after assigning window.location.href so no further code runs before the
+// browser navigates away.
+export function haltForNavigation(): Promise<never> {
+  return new Promise<never>(() => {});
+}

--- a/client/src/app/withings/withings.service.ts
+++ b/client/src/app/withings/withings.service.ts
@@ -39,7 +39,7 @@ export class WithingsService {
             } else {
               sessionStorage.setItem(REDIRECT_GUARD_KEY, '1');
               window.location.href = authorizeUrl;
-              return;
+              await new Promise<never>(() => {});
             }
           } else {
             this.snackBar.open('Unable to sync with Withings', 'Close', {

--- a/client/src/app/withings/withings.service.ts
+++ b/client/src/app/withings/withings.service.ts
@@ -2,6 +2,7 @@ import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { inject, Injectable, signal } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { fetchJson } from '../utils/fetchJson';
+import { haltForNavigation } from '../utils/auth';
 
 const REDIRECT_GUARD_KEY = 'withings-authorize-redirected';
 
@@ -39,7 +40,10 @@ export class WithingsService {
             } else {
               sessionStorage.setItem(REDIRECT_GUARD_KEY, '1');
               window.location.href = authorizeUrl;
-              await new Promise<never>(() => {});
+              // Keep this promise pending so StravaService (which awaits
+              // this.withingsService.sync()) does not proceed to make its own
+              // API call and trigger a competing redirect.
+              await haltForNavigation();
             }
           } else {
             this.snackBar.open('Unable to sync with Withings', 'Close', {


### PR DESCRIPTION
## Summary
Updated the Strava and Withings service authentication flows to use never-resolving promises instead of early returns after redirecting to the authorization URL.

## Key Changes
- **StravaService**: Replaced `return;` statement with `await new Promise<never>(() => {})` after setting redirect location
- **WithingsService**: Replaced `return;` statement with `await new Promise<never>(() => {})` after setting redirect location

## Implementation Details
Both changes follow the same pattern in their respective authorization flows. After setting `window.location.href` to redirect the user to the OAuth provider, the code now awaits a promise that never resolves instead of returning immediately. This ensures that any code following the redirect assignment is never executed, providing more explicit control flow semantics while the page navigation occurs.

The `Promise<never>` type indicates that the promise will never settle, which accurately reflects the intended behavior—the user will be redirected away before the promise could ever resolve.

https://claude.ai/code/session_01XVmXjufp5gnrQsnaUEWL15