### PR TITLE
Move book management to settings page, simplify dashboard

### DIFF
--- a/client/src/app/reading/reading-library.component.css
+++ b/client/src/app/reading/reading-library.component.css
@@ -1,0 +1,99 @@
+section {
+  display: grid;
+  gap: 16px;
+}
+
+h2 {
+  margin: 0;
+  color: var(--mat-sys-on-primary);
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.books {
+  display: grid;
+  gap: 16px;
+}
+
+.empty {
+  color: var(--mat-app-text-color);
+  text-align: center;
+  font-size: 14px;
+}
+
+.book {
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+  border-radius: 0.75rem;
+  background: var(--mat-sys-surface-container);
+}
+
+.book--completed {
+  opacity: 0.7;
+}
+
+.book-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.book-meta {
+  display: grid;
+  gap: 2px;
+}
+
+.book-title {
+  color: var(--mat-sys-on-primary);
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.book-author {
+  color: var(--mat-app-text-color);
+  font-size: 13px;
+  margin: 0;
+}
+
+.book-stats {
+  color: var(--mat-app-text-color);
+  font-size: 13px;
+  margin: 0;
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.add-book {
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+  border-radius: 0.75rem;
+  background: var(--mat-sys-surface-container);
+}
+
+.add-book h3 {
+  color: var(--mat-sys-on-primary);
+  font-size: 16px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.add-button {
+  justify-self: stretch;
+}
+
+.page-loading {
+  margin: 60px auto;
+}

--- a/client/src/app/reading/reading-library.component.html
+++ b/client/src/app/reading/reading-library.component.html
@@ -1,0 +1,132 @@
+@if (books.isLoading()) {
+<mat-spinner class="page-loading" />
+} @else {
+<section class="library" aria-labelledby="reading-library-heading">
+  <h2 id="reading-library-heading">Books</h2>
+
+  <div class="books">
+    @if (inProgressBooks().length === 0 && completedBooks().length === 0 &&
+    !addingBook()) {
+    <p class="empty">No books yet. Add your first one to get started.</p>
+    } @for (book of inProgressBooks(); track book.id) {
+    <article class="book" [attr.aria-label]="ariaForBook(book)">
+      <header class="book-header">
+        <div class="book-meta">
+          <h3 class="book-title">{{ book.title }}</h3>
+          <p class="book-author">{{ book.author }}</p>
+        </div>
+        <button
+          mat-icon-button
+          type="button"
+          [attr.aria-label]="'Remove ' + book.title"
+          [disabled]="busy()"
+          (click)="deleteBook(book)"
+        >
+          <mat-icon>delete_outline</mat-icon>
+        </button>
+      </header>
+      <p class="book-stats">
+        {{ book.currentPage }} / {{ book.totalPages }} pages
+        @if (averageLabel(book); as label) {
+        <span>· {{ label }}</span>
+        }
+      </p>
+    </article>
+    } @for (book of completedBooks(); track book.id) {
+    <article
+      class="book book--completed"
+      [attr.aria-label]="ariaForBook(book) + ', finished'"
+    >
+      <header class="book-header">
+        <div class="book-meta">
+          <h3 class="book-title">{{ book.title }}</h3>
+          <p class="book-author">{{ book.author }}</p>
+        </div>
+        <button
+          mat-icon-button
+          type="button"
+          [attr.aria-label]="'Remove ' + book.title"
+          [disabled]="busy()"
+          (click)="deleteBook(book)"
+        >
+          <mat-icon>delete_outline</mat-icon>
+        </button>
+      </header>
+      <p class="book-stats">
+        Finished · {{ book.totalPages }} pages
+        @if (averageLabel(book); as label) {
+        <span>· {{ label }}</span>
+        }
+      </p>
+    </article>
+    } @if (addingBook()) {
+    <form
+      class="add-book"
+      aria-labelledby="add-book-heading"
+      (submit)="submitBook(); $event.preventDefault()"
+    >
+      <h3 id="add-book-heading">Add a book</h3>
+      <mat-form-field appearance="outline">
+        <mat-label>Title</mat-label>
+        <input
+          matInput
+          name="title"
+          [ngModel]="draft().title"
+          (ngModelChange)="updateDraft('title', $event)"
+          required
+        />
+      </mat-form-field>
+      <mat-form-field appearance="outline">
+        <mat-label>Author</mat-label>
+        <input
+          matInput
+          name="author"
+          [ngModel]="draft().author"
+          (ngModelChange)="updateDraft('author', $event)"
+          required
+        />
+      </mat-form-field>
+      <mat-form-field appearance="outline">
+        <mat-label>Total pages</mat-label>
+        <input
+          matInput
+          name="totalPages"
+          type="number"
+          min="1"
+          [ngModel]="draft().totalPages"
+          (ngModelChange)="updateDraft('totalPages', $event)"
+          required
+        />
+      </mat-form-field>
+      <div class="actions">
+        <button
+          mat-stroked-button
+          type="button"
+          [disabled]="busy()"
+          (click)="cancelAddingBook()"
+        >
+          Cancel
+        </button>
+        <button
+          mat-flat-button
+          color="primary"
+          type="submit"
+          [disabled]="!canSubmit()"
+        >
+          Add book
+        </button>
+      </div>
+    </form>
+    } @else {
+    <button
+      mat-stroked-button
+      type="button"
+      class="add-button"
+      (click)="startAddingBook()"
+    >
+      Add book
+    </button>
+    }
+  </div>
+</section>
+}

--- a/client/src/app/reading/reading-library.component.ts
+++ b/client/src/app/reading/reading-library.component.ts
@@ -1,0 +1,109 @@
+import { Component, computed, inject, resource, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { Book, ReadingService } from './reading.service';
+
+type NewBookDraft = {
+  title: string;
+  author: string;
+  totalPages: number | null;
+};
+
+@Component({
+  standalone: true,
+  imports: [
+    FormsModule,
+    MatButtonModule,
+    MatFormFieldModule,
+    MatIconModule,
+    MatInputModule,
+    MatProgressSpinnerModule,
+  ],
+  selector: 'app-reading-library',
+  templateUrl: './reading-library.component.html',
+  styleUrl: './reading-library.component.css',
+})
+export class ReadingLibraryComponent {
+  private readonly readingService = inject(ReadingService);
+
+  readonly busy = signal(false);
+  readonly addingBook = signal(false);
+  readonly draft = signal<NewBookDraft>({ title: '', author: '', totalPages: null });
+
+  readonly books = resource({
+    params: () => this.readingService.version(),
+    loader: () => this.readingService.getBooks(),
+  });
+
+  readonly inProgressBooks = computed(
+    () => this.books.value()?.filter((book) => !book.completedAt) ?? []
+  );
+  readonly completedBooks = computed(
+    () => this.books.value()?.filter((book) => book.completedAt) ?? []
+  );
+
+  readonly canSubmit = computed(() => {
+    const d = this.draft();
+    return (
+      !this.busy() &&
+      d.title.trim().length > 0 &&
+      d.author.trim().length > 0 &&
+      typeof d.totalPages === 'number' &&
+      d.totalPages > 0
+    );
+  });
+
+  startAddingBook() {
+    this.draft.set({ title: '', author: '', totalPages: null });
+    this.addingBook.set(true);
+  }
+
+  cancelAddingBook() {
+    this.addingBook.set(false);
+  }
+
+  updateDraft<K extends keyof NewBookDraft>(field: K, value: NewBookDraft[K]) {
+    this.draft.update((d) => ({ ...d, [field]: value }));
+  }
+
+  async submitBook() {
+    if (!this.canSubmit()) return;
+    const d = this.draft();
+    this.busy.set(true);
+    try {
+      await this.readingService.addBook(
+        d.title.trim(),
+        d.author.trim(),
+        d.totalPages as number
+      );
+      this.addingBook.set(false);
+    } finally {
+      this.busy.set(false);
+    }
+  }
+
+  async deleteBook(book: Book) {
+    if (this.busy()) return;
+    this.busy.set(true);
+    try {
+      await this.readingService.deleteBook(book.id);
+    } finally {
+      this.busy.set(false);
+    }
+  }
+
+  ariaForBook(book: Book): string {
+    return `${book.title}, ${book.currentPage} of ${book.totalPages} pages`;
+  }
+
+  averageLabel(book: Book): string | null {
+    if (book.averagePagesPerDay === undefined || book.averagePagesPerDay === null) {
+      return null;
+    }
+    return `${book.averagePagesPerDay.toFixed(1)} pages/day avg`;
+  }
+}

--- a/client/src/app/reading/reading.component.html
+++ b/client/src/app/reading/reading.component.html
@@ -38,28 +38,15 @@
   }
 
   <div class="books">
-    @if (inProgressBooks().length === 0 && completedBooks().length === 0 &&
-    !addingBook()) {
-    <p class="empty">No books yet. Add your first one to get started.</p>
+    @if (inProgressBooks().length === 0) {
+    <p class="empty">No books in progress. Add a book in Settings.</p>
     } @for (book of inProgressBooks(); track book.id) {
-    <article
-      class="book"
-      [attr.aria-label]="ariaForBook(book)"
-    >
+    <article class="book" [attr.aria-label]="ariaForBook(book)">
       <header class="book-header">
         <div class="book-meta">
           <h3 class="book-title">{{ book.title }}</h3>
           <p class="book-author">{{ book.author }}</p>
         </div>
-        <button
-          mat-icon-button
-          type="button"
-          [attr.aria-label]="'Remove ' + book.title"
-          [disabled]="busy()"
-          (click)="deleteBook(book)"
-        >
-          <mat-icon>delete_outline</mat-icon>
-        </button>
       </header>
 
       <div class="book-progress-bar" aria-hidden="true">
@@ -102,100 +89,6 @@
         }
       </p>
     </article>
-    } @for (book of completedBooks(); track book.id) {
-    <article
-      class="book book--completed"
-      [attr.aria-label]="ariaForBook(book) + ', finished'"
-    >
-      <header class="book-header">
-        <div class="book-meta">
-          <h3 class="book-title">{{ book.title }}</h3>
-          <p class="book-author">{{ book.author }}</p>
-        </div>
-        <button
-          mat-icon-button
-          type="button"
-          [attr.aria-label]="'Remove ' + book.title"
-          [disabled]="busy()"
-          (click)="deleteBook(book)"
-        >
-          <mat-icon>delete_outline</mat-icon>
-        </button>
-      </header>
-      <p class="book-stats">
-        Finished · {{ book.totalPages }} pages
-        @if (averageLabel(book); as label) {
-        <span>· {{ label }}</span>
-        }
-      </p>
-    </article>
-    } @if (addingBook()) {
-    <form
-      class="add-book"
-      aria-labelledby="add-book-heading"
-      (submit)="submitBook(); $event.preventDefault()"
-    >
-      <h3 id="add-book-heading">Add a book</h3>
-      <mat-form-field appearance="outline">
-        <mat-label>Title</mat-label>
-        <input
-          matInput
-          name="title"
-          [ngModel]="draft().title"
-          (ngModelChange)="updateDraft('title', $event)"
-          required
-        />
-      </mat-form-field>
-      <mat-form-field appearance="outline">
-        <mat-label>Author</mat-label>
-        <input
-          matInput
-          name="author"
-          [ngModel]="draft().author"
-          (ngModelChange)="updateDraft('author', $event)"
-          required
-        />
-      </mat-form-field>
-      <mat-form-field appearance="outline">
-        <mat-label>Total pages</mat-label>
-        <input
-          matInput
-          name="totalPages"
-          type="number"
-          min="1"
-          [ngModel]="draft().totalPages"
-          (ngModelChange)="updateDraft('totalPages', $event)"
-          required
-        />
-      </mat-form-field>
-      <div class="actions">
-        <button
-          mat-stroked-button
-          type="button"
-          [disabled]="busy()"
-          (click)="cancelAddingBook()"
-        >
-          Cancel
-        </button>
-        <button
-          mat-flat-button
-          color="primary"
-          type="submit"
-          [disabled]="!canSubmit()"
-        >
-          Add book
-        </button>
-      </div>
-    </form>
-    } @else {
-    <button
-      mat-stroked-button
-      type="button"
-      class="add-button"
-      (click)="startAddingBook()"
-    >
-      Add book
-    </button>
     }
   </div>
 </section>

--- a/client/src/app/reading/reading.component.ts
+++ b/client/src/app/reading/reading.component.ts
@@ -2,16 +2,9 @@ import { Component, computed, inject, resource, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { Book, ReadingService } from './reading.service';
-
-type NewBookDraft = {
-  title: string;
-  author: string;
-  totalPages: number | null;
-};
 
 @Component({
   standalone: true,
@@ -19,7 +12,6 @@ type NewBookDraft = {
     FormsModule,
     MatButtonModule,
     MatFormFieldModule,
-    MatIconModule,
     MatInputModule,
     MatProgressSpinnerModule,
   ],
@@ -31,8 +23,6 @@ export class ReadingComponent {
   private readonly readingService = inject(ReadingService);
 
   readonly busy = signal(false);
-  readonly addingBook = signal(false);
-  readonly draft = signal<NewBookDraft>({ title: '', author: '', totalPages: null });
   readonly progressInputs = signal<Record<string, number>>({});
 
   readonly books = resource({
@@ -59,49 +49,6 @@ export class ReadingComponent {
   readonly inProgressBooks = computed(
     () => this.books.value()?.filter((book) => !book.completedAt) ?? []
   );
-  readonly completedBooks = computed(
-    () => this.books.value()?.filter((book) => book.completedAt) ?? []
-  );
-
-  readonly canSubmit = computed(() => {
-    const d = this.draft();
-    return (
-      !this.busy() &&
-      d.title.trim().length > 0 &&
-      d.author.trim().length > 0 &&
-      typeof d.totalPages === 'number' &&
-      d.totalPages > 0
-    );
-  });
-
-  startAddingBook() {
-    this.draft.set({ title: '', author: '', totalPages: null });
-    this.addingBook.set(true);
-  }
-
-  cancelAddingBook() {
-    this.addingBook.set(false);
-  }
-
-  updateDraft<K extends keyof NewBookDraft>(field: K, value: NewBookDraft[K]) {
-    this.draft.update((d) => ({ ...d, [field]: value }));
-  }
-
-  async submitBook() {
-    if (!this.canSubmit()) return;
-    const d = this.draft();
-    this.busy.set(true);
-    try {
-      await this.readingService.addBook(
-        d.title.trim(),
-        d.author.trim(),
-        d.totalPages as number
-      );
-      this.addingBook.set(false);
-    } finally {
-      this.busy.set(false);
-    }
-  }
 
   pageInputValue(book: Book): number {
     return this.progressInputs()[book.id] ?? book.currentPage;
@@ -123,16 +70,6 @@ export class ReadingComponent {
         delete next[book.id];
         return next;
       });
-    } finally {
-      this.busy.set(false);
-    }
-  }
-
-  async deleteBook(book: Book) {
-    if (this.busy()) return;
-    this.busy.set(true);
-    try {
-      await this.readingService.deleteBook(book.id);
     } finally {
       this.busy.set(false);
     }

--- a/client/src/app/settings/settings.component.html
+++ b/client/src/app/settings/settings.component.html
@@ -59,4 +59,6 @@
       </div>
     </form>
   }
+
+  <app-reading-library></app-reading-library>
 </section>

--- a/client/src/app/settings/settings.component.ts
+++ b/client/src/app/settings/settings.component.ts
@@ -4,6 +4,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { ReadingLibraryComponent } from '../reading/reading-library.component';
 import { GoldenDayGoal, SettingsService } from './settings.service';
 
 @Component({
@@ -16,6 +17,7 @@ import { GoldenDayGoal, SettingsService } from './settings.service';
     MatFormFieldModule,
     MatInputModule,
     MatProgressSpinnerModule,
+    ReadingLibraryComponent,
   ],
   templateUrl: './settings.component.html',
   styleUrl: './settings.component.css',

--- a/test/tests/reading.spec.ts
+++ b/test/tests/reading.spec.ts
@@ -34,8 +34,16 @@ test.describe('Reading', () => {
 
     const section = page.getByRole('region', { name: 'Reading' });
     await expect(section).toBeVisible();
-    await expect(section.getByText('No books yet. Add your first one to get started.')).toBeVisible();
+    await expect(
+      section.getByText('No books in progress. Add a book in Settings.')
+    ).toBeVisible();
     await expect(section.getByRole('img', { name: '0 of 30 pages today' })).toBeVisible();
+
+    await page.goto('/settings');
+    const library = page.getByRole('region', { name: 'Books' });
+    await expect(
+      library.getByText('No books yet. Add your first one to get started.')
+    ).toBeVisible();
   });
 
   test('hides daily goal ring when reading goal is 0', async ({ page }) => {
@@ -45,24 +53,48 @@ test.describe('Reading', () => {
     await expect(section.getByRole('img', { name: /pages today/ })).toBeHidden();
   });
 
-  test('adds a new book through the form', async ({ page }) => {
-    await page.goto('/');
-    const section = page.getByRole('region', { name: 'Reading' });
+  test('adds a new book through the settings page', async ({ page }) => {
+    await page.goto('/settings');
+    const library = page.getByRole('region', { name: 'Books' });
 
-    await section.getByRole('button', { name: 'Add book' }).click();
-    await section.getByLabel('Title').fill('The Pragmatic Programmer');
-    await section.getByLabel('Author').fill('David Thomas');
-    await section.getByLabel('Total pages').fill('320');
-    await section.getByRole('button', { name: 'Add book' }).click();
+    await library.getByRole('button', { name: 'Add book' }).click();
+    await library.getByLabel('Title').fill('The Pragmatic Programmer');
+    await library.getByLabel('Author').fill('David Thomas');
+    await library.getByLabel('Total pages').fill('320');
+    await library.getByRole('button', { name: 'Add book' }).click();
 
-    await expect(section.getByRole('heading', { name: 'The Pragmatic Programmer' })).toBeVisible();
-    await expect(section.getByText('David Thomas')).toBeVisible();
+    await expect(
+      library.getByRole('heading', { name: 'The Pragmatic Programmer' })
+    ).toBeVisible();
+    await expect(library.getByText('David Thomas')).toBeVisible();
 
     const books = await getBookRows();
     expect(books).toHaveLength(1);
     expect(books[0].title).toBe('The Pragmatic Programmer');
     expect(books[0].author).toBe('David Thomas');
     expect(books[0].total_pages).toBe(320);
+
+    await page.goto('/');
+    const section = page.getByRole('region', { name: 'Reading' });
+    await expect(
+      section.getByRole('heading', { name: 'The Pragmatic Programmer' })
+    ).toBeVisible();
+  });
+
+  test('does not expose book add or remove controls on the dashboard', async ({
+    page,
+  }) => {
+    const bookId = randomUUID();
+    await insertBook(bookId, 'Dashboard Only', 'Author', 200, daysAgoAt(1, 8));
+
+    await page.goto('/');
+    const section = page.getByRole('region', { name: 'Reading' });
+    await expect(
+      section.getByRole('button', { name: 'Add book' })
+    ).toHaveCount(0);
+    await expect(
+      section.getByRole('button', { name: 'Remove Dashboard Only' })
+    ).toHaveCount(0);
   });
 
   test('updates reading progress for a book', async ({ page }) => {
@@ -136,28 +168,68 @@ test.describe('Reading', () => {
     await section.getByRole('button', { name: 'Save' }).click();
 
     await expect(
-      section.getByRole('article', { name: /Almost Done, 100 of 100 pages, finished/ })
+      section.getByRole('heading', { name: 'Almost Done' })
+    ).toBeHidden();
+
+    await page.goto('/settings');
+    const library = page.getByRole('region', { name: 'Books' });
+    await expect(
+      library.getByRole('article', {
+        name: /Almost Done, 100 of 100 pages, finished/,
+      })
     ).toBeVisible();
 
     const books = await getBookRows();
     expect(books[0].completed_at).not.toBeNull();
   });
 
-  test('removes a book and its progress entries', async ({ page }) => {
+  test('removes a book and its progress entries from the settings page', async ({
+    page,
+  }) => {
     const bookId = randomUUID();
     await insertBook(bookId, 'Removable', 'Author', 100, daysAgoAt(1, 8));
     await insertReadingProgress(bookId, 25, daysAgoAt(0, 12));
 
-    await page.goto('/');
-    const section = page.getByRole('region', { name: 'Reading' });
-    await section.getByRole('button', { name: 'Remove Removable' }).click();
+    await page.goto('/settings');
+    const library = page.getByRole('region', { name: 'Books' });
+    await library.getByRole('button', { name: 'Remove Removable' }).click();
 
     await expect(
-      section.getByRole('heading', { name: 'Removable' })
+      library.getByRole('heading', { name: 'Removable' })
     ).toBeHidden();
 
     expect(await getBookRows()).toHaveLength(0);
     expect(await getReadingProgressRows()).toHaveLength(0);
+  });
+
+  test('shows finished books only on the settings page', async ({ page }) => {
+    const bookId = randomUUID();
+    const finishedAt = daysAgoAt(1, 12);
+    await insertBook(
+      bookId,
+      'Already Finished',
+      'Author',
+      150,
+      daysAgoAt(5, 8),
+      finishedAt
+    );
+
+    await page.goto('/');
+    const section = page.getByRole('region', { name: 'Reading' });
+    await expect(
+      section.getByRole('heading', { name: 'Already Finished' })
+    ).toBeHidden();
+
+    await page.goto('/settings');
+    const library = page.getByRole('region', { name: 'Books' });
+    await expect(
+      library.getByRole('heading', { name: 'Already Finished' })
+    ).toBeVisible();
+    await expect(
+      library.getByRole('article', {
+        name: /Already Finished, 0 of 150 pages, finished/,
+      })
+    ).toBeVisible();
   });
 
   test('reflects the configured daily reading goal', async ({ page }) => {


### PR DESCRIPTION
## Summary
Refactored the reading feature to separate book management (add/remove/view all books) from the reading dashboard. Book management is now exclusively in the Settings page, while the dashboard focuses on displaying only in-progress books and tracking daily reading progress.

## Key Changes
- **New component**: Created `ReadingLibraryComponent` to handle all book management operations (add, delete, view completed books)
- **Dashboard simplification**: Removed add/delete book functionality from `ReadingComponent`, now displays only in-progress books
- **Settings integration**: Added `ReadingLibraryComponent` to the Settings page for centralized book management
- **Updated messaging**: Changed empty state text on dashboard from "No books yet" to "No books in progress. Add a book in Settings."
- **Completed books visibility**: Completed books now only appear in Settings, not on the dashboard
- **Styling**: Added dedicated stylesheet for the library component with proper layout and visual hierarchy

## Implementation Details
- Both components share the same `ReadingService` for data operations
- The library component uses Angular's new control flow syntax (`@if`, `@for`) and resource API
- Book filtering is handled via computed signals (`inProgressBooks`, `completedBooks`)
- Form state management for adding books is isolated to the library component
- Tests updated to reflect new page structure and user workflows

https://claude.ai/code/session_01CVM5b3SaeUAcbdfVjePBGT