### PR TITLE
Migrate deployment to Azure Key Vault and update Angular dev port

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -233,19 +233,20 @@ jobs:
       cancel-in-progress: false
     needs: [publish-server, publish-client]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
-      # - name: Connect to Twingate
-      #   uses: twingate/github-action@v1
-      #   with:
-      #     service-key: ${{ secrets.TWINGATE_SERVICE_KEY }}
+      - uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Deploy to Kubernetes
         env:
-          K8S_CONFIG: ${{ secrets.K8S_CONFIG }}
-          HOSTNAME: ${{ secrets.HOSTNAME }}
-          API_CLIENT_ID: ${{ secrets.API_CLIENT_ID }}
+          AZURE_KEYVAULT_NAME: ${{ secrets.AZURE_KEYVAULT_NAME }}
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          AZURE_KEYVAULT_ENDPOINT: ${{ secrets.AZURE_KEYVAULT_ENDPOINT }}
         run: scripts/deploy.sh

--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
+    "start": "ng serve --port 4280",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "vitest run"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,11 +2,13 @@
 
 set -e  # Exit immediately if a command exits with a non-zero status
 
-: "${K8S_CONFIG:?Environment variable K8S_CONFIG is required}"
-: "${HOSTNAME:?Environment variable HOSTNAME is required}"
-: "${API_CLIENT_ID:?Environment variable API_CLIENT_ID is required}"
+: "${AZURE_KEYVAULT_NAME:?Environment variable AZURE_KEYVAULT_NAME is required}"
 : "${DOCKERHUB_USERNAME:?Environment variable DOCKERHUB_USERNAME is required}"
-: "${AZURE_KEYVAULT_ENDPOINT:?Environment variable AZURE_KEYVAULT_ENDPOINT is required}"
+
+AZURE_KEYVAULT_ENDPOINT="https://${AZURE_KEYVAULT_NAME}.vault.azure.net/"
+K8S_CONFIG=$(az keyvault secret show --vault-name "$AZURE_KEYVAULT_NAME" --name k8s-config --query value -o tsv)
+HOSTNAME=$(az keyvault secret show --vault-name "$AZURE_KEYVAULT_NAME" --name hostname --query value -o tsv)
+API_CLIENT_ID=$(az keyvault secret show --vault-name "$AZURE_KEYVAULT_NAME" --name api-client-id --query value -o tsv)
 
 # Create a temporary file in /dev/shm (RAM) to avoid writing to disk
 KUBECONFIG_FILE=$(mktemp /dev/shm/kubeconfig.XXXXXX)


### PR DESCRIPTION
## Summary
This PR refactors the deployment workflow to use Azure Key Vault for secret management instead of passing secrets directly through GitHub Actions, and updates the Angular development server port.

## Key Changes
- **GitHub Actions Workflow**: 
  - Replaced Twingate VPN connection with Azure login using OIDC (OpenID Connect) for secure authentication
  - Added required permissions for OIDC token generation (`id-token: write`, `contents: read`)
  - Removed direct secret environment variables (`K8S_CONFIG`, `HOSTNAME`, `API_CLIENT_ID`, `AZURE_KEYVAULT_ENDPOINT`)
  - Now only passes `AZURE_KEYVAULT_NAME` and `DOCKERHUB_USERNAME` to the deployment script

- **Deployment Script**:
  - Removed requirement for secrets to be passed as environment variables
  - Now dynamically retrieves secrets from Azure Key Vault using `az keyvault secret show` commands
  - Constructs the Key Vault endpoint URL from the vault name
  - Fetches `k8s-config`, `hostname`, and `api-client-id` secrets from the vault at runtime

- **Angular Development**:
  - Updated the `start` script to run the development server on port 4280 instead of the default port 4200

## Implementation Details
The deployment now follows a more secure pattern by leveraging Azure's native secret management. Instead of storing sensitive configuration in GitHub secrets, they are retrieved on-demand from Azure Key Vault during deployment, reducing the attack surface and improving secret rotation capabilities.

https://claude.ai/code/session_01Wqppq6Bve2Rb32h7jJ86m9