### PR TITLE
Add Prometheus metrics and filter kube-probe logs from nginx

### DIFF
--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -1,6 +1,13 @@
+map $http_user_agent $loggable {
+    ~kube-probe 0;
+    default     1;
+}
+
 server {
     listen 8000;
     listen [::]:8000;
+
+    access_log /var/log/nginx/access.log combined if=$loggable;
 
     root /usr/share/nginx/html;
 

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -36,6 +36,11 @@
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-jpa</artifactId>
     </dependency>


### PR DESCRIPTION
## Summary
This PR adds observability improvements by enabling Prometheus metrics collection and reducing log noise from Kubernetes health probes in nginx.

## Key Changes
- **Nginx logging**: Added conditional access logging to exclude kube-probe requests from nginx access logs, reducing log volume from Kubernetes health checks
- **Prometheus metrics**: Added micrometer Prometheus registry dependency to enable metrics export from the Spring Boot application

## Implementation Details
- Configured an nginx `map` directive to set a `$loggable` variable that filters out requests with `kube-probe` in the User-Agent header
- Applied the `if=$loggable` condition to the access log directive to only log relevant traffic
- Added `micrometer-registry-prometheus` as a runtime dependency to the Spring Boot application, which works in conjunction with the existing `spring-boot-starter-actuator` to expose Prometheus-compatible metrics

https://claude.ai/code/session_01TfArk3jM5envHnBVEMX5Ty