### PR TITLE
Clear EntityManager cache after batch deleting fitness records

### DIFF
--- a/server/src/main/java/mucsi96/traininglog/fitness/FitnessService.java
+++ b/server/src/main/java/mucsi96/traininglog/fitness/FitnessService.java
@@ -17,6 +17,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import mucsi96.traininglog.rides.Ride;
@@ -31,6 +32,7 @@ public class FitnessService {
 
   private final RideRepository rideRepository;
   private final FitnessRepository fitnessRepository;
+  private final EntityManager entityManager;
   private final Clock clock;
 
   @Transactional
@@ -86,6 +88,7 @@ public class FitnessService {
             Collectors.summingDouble(ride -> ride.getSufferScore().doubleValue())));
 
     fitnessRepository.deleteAllInBatch();
+    entityManager.clear();
 
     LocalDate today = LocalDate.now(clock.withZone(zoneId));
     LocalDate cursor = loadByDay.isEmpty() ? today : loadByDay.keySet().iterator().next();


### PR DESCRIPTION
## Summary
Added EntityManager cache clearing in the FitnessService to prevent stale entity references after batch deleting fitness records during recomputation.

## Key Changes
- Injected `EntityManager` dependency into `FitnessService`
- Added `entityManager.clear()` call immediately after `fitnessRepository.deleteAllInBatch()` in the `recompute()` method

## Implementation Details
The EntityManager cache can hold references to deleted entities, which may cause issues when subsequent operations attempt to work with fitness records. By explicitly clearing the persistence context after the batch delete operation, we ensure that any subsequent queries will fetch fresh data from the database rather than using stale cached entities.

This is a common pattern when performing batch operations in JPA/Hibernate to maintain data consistency and prevent unexpected behavior from cached entity states.

https://claude.ai/code/session_01D64w3x7Q9LE3EbdUPjHmC5