### PR TITLE
Persist fitness entities directly instead of batch saving

### DIFF
--- a/server/src/main/java/mucsi96/traininglog/fitness/FitnessService.java
+++ b/server/src/main/java/mucsi96/traininglog/fitness/FitnessService.java
@@ -6,7 +6,6 @@ import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -96,12 +95,11 @@ public class FitnessService {
 
     double fitness = 0;
     double fatigue = 0;
-    List<Fitness> series = new ArrayList<>();
     while (!cursor.isAfter(end)) {
       double load = loadByDay.getOrDefault(cursor, 0.0);
       fitness = LAMBDA_FITNESS * fitness + (1 - LAMBDA_FITNESS) * load;
       fatigue = LAMBDA_FATIGUE * fatigue + (1 - LAMBDA_FATIGUE) * load;
-      series.add(Fitness.builder()
+      entityManager.persist(Fitness.builder()
           .createdAt(cursor.atStartOfDay(zoneId).withZoneSameInstant(ZoneOffset.UTC))
           .pulledAt(pulledAt)
           .fitness((float) fitness)
@@ -110,7 +108,5 @@ public class FitnessService {
           .build());
       cursor = cursor.plusDays(1);
     }
-
-    fitnessRepository.saveAll(series);
   }
 }


### PR DESCRIPTION
## Summary
Changed the fitness data persistence strategy from batch saving to direct entity persistence, eliminating the intermediate list accumulation.

## Key Changes
- Removed `ArrayList` import and `series` list variable that accumulated `Fitness` entities
- Changed from collecting entities in a list and calling `fitnessRepository.saveAll(series)` to directly persisting each entity via `entityManager.persist()` within the loop
- Simplified the recompute method by removing the batch save operation at the end

## Implementation Details
The change moves from a batch persistence pattern to immediate persistence of each `Fitness` entity as it's created during the daily fitness/fatigue calculation loop. This approach may be beneficial for:
- Reducing memory overhead by not holding all entities in memory
- Allowing the persistence context to manage entities individually
- Potentially enabling transaction flushing at regular intervals if needed

Note: This change assumes the calling context has an active transaction and that immediate persistence is the desired behavior.

https://claude.ai/code/session_01HbMZcM4MYbSrqoYMnHoAag