### PR TITLE
Replace custom measurement pipe with Angular DecimalPipe

### DIFF
--- a/client/src/app/fitness/fitness.component.html
+++ b/client/src/app/fitness/fitness.component.html
@@ -15,7 +15,7 @@
   </div>
   <article>
     <h2>Fitness</h2>
-    <p class="value">{{ value.fitness | measurementWithUnit : "" : 0 }}</p>
+    <p class="value">{{ value.fitness | number : "1.0-0" }}</p>
   </article>
 </section>
 }

--- a/client/src/app/fitness/fitness.component.ts
+++ b/client/src/app/fitness/fitness.component.ts
@@ -1,3 +1,4 @@
+import { DecimalPipe } from '@angular/common';
 import { Component, computed, inject, resource } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
@@ -6,14 +7,13 @@ import { NgxEchartsModule } from 'ngx-echarts';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { map } from 'rxjs';
 import { FitnessMeasurement, FitnessService } from './fitness.service';
-import { MeasurementWithUnitPipe } from '../utils/measurement-with-unit.pipe';
 
 @Component({
   standalone: true,
   imports: [
     NgxEchartsModule,
     MatProgressSpinnerModule,
-    MeasurementWithUnitPipe,
+    DecimalPipe,
   ],
   selector: 'app-fitness',
   templateUrl: './fitness.component.html',

--- a/test/tests/strava.spec.ts
+++ b/test/tests/strava.spec.ts
@@ -148,6 +148,7 @@ test.describe('Fitness without a ride today', () => {
     await expect(fitnessSection.getByRole('heading', { name: 'Fitness' })).toBeVisible();
     const chart = fitnessSection.locator('[role="img"]');
     await expect(chart).toHaveAttribute('aria-label', /Line chart.*Fitness/);
+    await expect(fitnessSection.getByText('0', { exact: true })).toBeVisible();
 
     const rows = await getFitnessRows();
     expect(rows).toHaveLength(1);


### PR DESCRIPTION
## Summary
Replaced the custom `MeasurementWithUnitPipe` with Angular's built-in `DecimalPipe` for formatting the fitness value display, simplifying the codebase and reducing custom pipe dependencies.

## Key Changes
- Removed import of `MeasurementWithUnitPipe` from the fitness component
- Added import of `DecimalPipe` from `@angular/common`
- Updated component imports to use `DecimalPipe` instead of `MeasurementWithUnitPipe`
- Changed template binding from `{{ value.fitness | measurementWithUnit : "" : 0 }}` to `{{ value.fitness | number : "1.0-0" }}` to format the fitness value with one integer digit and zero decimal places
- Added test assertion to verify the formatted fitness value is visible in the UI

## Implementation Details
The `DecimalPipe` with format `"1.0-0"` provides the same formatting behavior as the previous custom pipe, displaying the fitness value as a whole number without decimal places. This change reduces code complexity while maintaining the same visual output.

https://claude.ai/code/session_01A7rW82t3a6tBNE9nAkQUbx