### PR TITLE
Show today and period fitness point changes

### DIFF
--- a/client/src/app/fitness/fitness.component.css
+++ b/client/src/app/fitness/fitness.component.css
@@ -28,6 +28,27 @@ h2 {
   font-weight: 700;
 }
 
+.diff-value {
+  font-size: 14px;
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.diff-label {
+  color: var(--mat-app-text-color);
+  opacity: 0.7;
+  font-weight: 400;
+}
+
+.diff-value.green {
+  color: hsl(111, 32%, 66%);
+}
+
+.diff-value.red {
+  color: hsl(0, 91%, 74%);
+}
+
 .chart-wrapper {
   aspect-ratio: 1;
   min-width: 100px;

--- a/client/src/app/fitness/fitness.component.html
+++ b/client/src/app/fitness/fitness.component.html
@@ -1,5 +1,7 @@
 @let value = latest();
 @let chart = chartOptions();
+@let todayDiffVal = todayDiff();
+@let periodDiffVal = periodDiff();
 @if (todayFitness.isLoading() || periodFitness.isLoading()) {
 <mat-spinner class="page-loading" />
 } @else if (value && chart) {
@@ -16,6 +18,14 @@
   <article>
     <h2>Fitness</h2>
     <p class="value">{{ value.fitness | number : "1.0-0" }}</p>
+    <p [class]="'diff-value ' + (todayDiffVal | percentageDiffColor)">
+      <span class="diff-label">Today</span>
+      <span>{{ todayDiffVal | pointsDiff }}</span>
+    </p>
+    <p [class]="'diff-value ' + (periodDiffVal | percentageDiffColor)">
+      <span class="diff-label">Period</span>
+      <span>{{ periodDiffVal | pointsDiff }}</span>
+    </p>
   </article>
 </section>
 }

--- a/client/src/app/fitness/fitness.component.ts
+++ b/client/src/app/fitness/fitness.component.ts
@@ -7,6 +7,8 @@ import { NgxEchartsModule } from 'ngx-echarts';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { map } from 'rxjs';
 import { FitnessMeasurement, FitnessService } from './fitness.service';
+import { PercentageDiffColorPipe } from '../utils/percentage-diff-color.pipe';
+import { PointsDiffPipe } from '../utils/points-diff.pipe';
 
 @Component({
   standalone: true,
@@ -14,6 +16,8 @@ import { FitnessMeasurement, FitnessService } from './fitness.service';
     NgxEchartsModule,
     MatProgressSpinnerModule,
     DecimalPipe,
+    PercentageDiffColorPipe,
+    PointsDiffPipe,
   ],
   selector: 'app-fitness',
   templateUrl: './fitness.component.html',
@@ -28,7 +32,7 @@ export class FitnessComponent {
   readonly initOpts = { renderer: 'svg' as const };
 
   readonly todayFitness = resource({
-    loader: () => this.fitnessService.getFitness(1),
+    loader: () => this.fitnessService.getFitness(2),
   });
 
   readonly periodFitness = resource({
@@ -39,6 +43,26 @@ export class FitnessComponent {
   readonly latest = computed<FitnessMeasurement | undefined>(() => {
     const today = this.todayFitness.value();
     return today?.measurements.at(-1);
+  });
+
+  readonly todayDiff = computed<number | undefined>(() => {
+    const measurements = this.todayFitness.value()?.measurements;
+    if (!measurements || measurements.length < 2) {
+      return undefined;
+    }
+    const previous = measurements[measurements.length - 2];
+    const latest = measurements[measurements.length - 1];
+    return latest.fitness - previous.fitness;
+  });
+
+  readonly periodDiff = computed<number | undefined>(() => {
+    const measurements = this.periodFitness.value()?.measurements;
+    if (!measurements || measurements.length < 2) {
+      return undefined;
+    }
+    const initial = measurements[0];
+    const latest = measurements[measurements.length - 1];
+    return latest.fitness - initial.fitness;
   });
 
   readonly chartOptions = computed<EChartsOption | undefined>(() => {

--- a/client/src/app/utils/points-diff.pipe.spec.ts
+++ b/client/src/app/utils/points-diff.pipe.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { PointsDiffPipe } from './points-diff.pipe';
+
+describe('PointsDiffPipe', () => {
+  [
+    { input: 5.43, output: '↑ 5.4' },
+    { input: 0.12, output: '↑ 0.1' },
+    { input: 0.04, output: '-' },
+    { input: 0, output: '-' },
+    { input: undefined, output: '-' },
+    { input: -2.78, output: '↓ 2.8' },
+    { input: -0.12, output: '↓ 0.1' },
+    { input: -0.04, output: '-' },
+  ].forEach(({ input, output }) =>
+    it(`formats ${input} as ${output}`, () => {
+      const pipe = new PointsDiffPipe();
+      expect(pipe.transform(input)).toBe(output);
+    })
+  );
+});

--- a/client/src/app/utils/points-diff.pipe.ts
+++ b/client/src/app/utils/points-diff.pipe.ts
@@ -1,0 +1,19 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'pointsDiff',
+  standalone: true,
+})
+export class PointsDiffPipe implements PipeTransform {
+  transform(value: number | undefined = 0): string {
+    const rounded = parseInt((10 * (value ?? 0)).toFixed(0));
+
+    if (rounded > 0) {
+      return `↑ ${rounded / 10}`;
+    } else if (rounded < 0) {
+      return `↓ ${-rounded / 10}`;
+    }
+
+    return '-';
+  }
+}

--- a/test/tests/fitness.spec.ts
+++ b/test/tests/fitness.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect } from '../fixtures';
+import { cleanupDb, populateOAuthClients, insertRide } from '../utils';
+
+test.describe('Fitness diff', () => {
+  test.beforeEach(async () => {
+    await cleanupDb();
+    await populateOAuthClients();
+  });
+
+  test('shows today and period change when fitness has progressed', async ({ page }) => {
+    // Ride 7 days ago + today produces a higher fitness today than yesterday
+    // (yesterday decays without a ride) and a larger gain over the whole period.
+    await insertRide(7, 1740, 56000, 8400, 'Week ago', 'Ride', 1032, 200, 244);
+    await insertRide(0, 1740, 56000, 8400, 'Today', 'Ride', 1032, 200, 244);
+
+    await page.goto('/');
+
+    const fitnessSection = page.locator('section').filter({ hasText: 'Fitness' });
+    await expect(fitnessSection.getByRole('heading', { name: 'Fitness' })).toBeVisible();
+
+    const todayRow = fitnessSection.locator('p', { hasText: 'Today' });
+    await expect(todayRow).toBeVisible();
+    await expect(todayRow).toHaveText(/Today.*↑/);
+    await expect(todayRow).toHaveClass(/green/);
+
+    const periodRow = fitnessSection.locator('p', { hasText: 'Period' });
+    await expect(periodRow).toBeVisible();
+    await expect(periodRow).toHaveText(/Period.*↑/);
+    await expect(periodRow).toHaveClass(/green/);
+  });
+
+  test('shows a downward today diff when fitness decays without a ride', async ({ page }) => {
+    // Ride 2 days ago, no rides since. Yesterday and today both decay,
+    // so today's fitness is lower than yesterday's.
+    await insertRide(2, 1740, 56000, 8400, 'Two days ago', 'Ride', 1032, 200, 244);
+
+    await page.goto('/');
+
+    const fitnessSection = page.locator('section').filter({ hasText: 'Fitness' });
+    await expect(fitnessSection.getByRole('heading', { name: 'Fitness' })).toBeVisible();
+
+    const todayRow = fitnessSection.locator('p', { hasText: 'Today' });
+    await expect(todayRow).toHaveText(/Today.*↓/);
+    await expect(todayRow).toHaveClass(/red/);
+  });
+
+  test('shows period diff over the selected month timeframe', async ({ page }) => {
+    // Ride 25 days ago, ride today: period diff for month covers both samples.
+    await insertRide(25, 1740, 56000, 8400, 'Month ago', 'Ride', 1032, 200, 244);
+    await insertRide(0, 1740, 56000, 8400, 'Today', 'Ride', 1032, 200, 244);
+
+    await page.goto('/');
+    await page.getByRole('link', { name: 'Month' }).click();
+
+    const fitnessSection = page.locator('section').filter({ hasText: 'Fitness' });
+    await expect(fitnessSection.getByRole('heading', { name: 'Fitness' })).toBeVisible();
+
+    const periodRow = fitnessSection.locator('p', { hasText: 'Period' });
+    await expect(periodRow).toHaveText(/Period.*↑/);
+    await expect(periodRow).toHaveClass(/green/);
+  });
+
+  test('renders a placeholder when there is only one fitness measurement', async ({ page }) => {
+    // A ride only today: recompute persists exactly one fitness row.
+    await insertRide(0, 1740, 56000, 8400, 'Today', 'Ride', 1032, 200, 244);
+
+    await page.goto('/');
+
+    const fitnessSection = page.locator('section').filter({ hasText: 'Fitness' });
+    await expect(fitnessSection.getByRole('heading', { name: 'Fitness' })).toBeVisible();
+
+    const todayRow = fitnessSection.locator('p', { hasText: 'Today' });
+    await expect(todayRow).toHaveText(/Today.*-/);
+    const periodRow = fitnessSection.locator('p', { hasText: 'Period' });
+    await expect(periodRow).toHaveText(/Period.*-/);
+  });
+});


### PR DESCRIPTION
Display absolute fitness point deltas next to the current value, mirroring
the diff pattern used by the weight section so users can see how much
their fitness moved today and over the selected timeframe.