### PR TITLE
Add baseline weight measurement to weight history API

### DIFF
--- a/client/src/app/weight/weight.component.html
+++ b/client/src/app/weight/weight.component.html
@@ -1,7 +1,7 @@
 @let today = todayWeight.value();
 @let diffVal = diff();
 @let chart = chartOptions();
-@if (todayWeight.isLoading() || periodMeasurements.isLoading()) {
+@if (todayWeight.isLoading() || periodHistory.isLoading()) {
 <mat-spinner class="page-loading" />
 } @else if (chart) {
 <section>

--- a/client/src/app/weight/weight.component.ts
+++ b/client/src/app/weight/weight.component.ts
@@ -35,19 +35,23 @@ export class WeightComponent {
     loader: () => this.weightService.getTodayWeight(),
   });
 
-  readonly periodMeasurements = resource({
+  readonly periodHistory = resource({
     params: () => this.period(),
     loader: ({ params: period }) => this.weightService.getWeight(period),
   });
 
   readonly diff = computed(() => {
-    const measurements = this.periodMeasurements.value();
-    if (!measurements || measurements.length < 2) {
+    const history = this.periodHistory.value();
+    if (!history || history.measurements.length === 0) {
       return undefined;
     }
 
-    const initial = measurements[0];
-    const latest = measurements[measurements.length - 1];
+    const initial = history.baseline ?? history.measurements[0];
+    const latest = history.measurements[history.measurements.length - 1];
+
+    if (initial === latest) {
+      return undefined;
+    }
 
     return {
       date: latest.date,
@@ -66,10 +70,14 @@ export class WeightComponent {
   });
 
   readonly chartOptions = computed<EChartsOption | undefined>(() => {
-    const measurements = this.periodMeasurements.value();
-    if (!measurements || measurements.length === 0) {
+    const history = this.periodHistory.value();
+    if (!history || history.measurements.length === 0) {
       return undefined;
     }
+
+    const chartMeasurements: WeightMeasurement[] = history.baseline
+      ? [history.baseline, ...history.measurements]
+      : history.measurements;
 
     return {
       aria: {
@@ -85,7 +93,7 @@ export class WeightComponent {
       dataset: {
         source: [
           ['date', 'weight'],
-          ...measurements.map(({ date, weight }: WeightMeasurement) => [
+          ...chartMeasurements.map(({ date, weight }: WeightMeasurement) => [
             new Date(date),
             weight,
           ]),

--- a/client/src/app/weight/weight.service.ts
+++ b/client/src/app/weight/weight.service.ts
@@ -11,14 +11,24 @@ export type WeightMeasurement = {
   fatMassWeight?: number;
 };
 
+export type WeightHistory = {
+  measurements: WeightMeasurement[];
+  baseline?: WeightMeasurement;
+};
+
+type WeightHistoryResponse = {
+  measurements: WeightMeasurement[];
+  baseline?: WeightMeasurement;
+};
+
 @Injectable({ providedIn: 'root' })
 export class WeightService {
   private readonly http = inject(HttpClient);
   private readonly withingsService = inject(WithingsService);
   private readonly snackBar = inject(MatSnackBar);
-  private readonly cache = new Map<number, WeightMeasurement[]>();
+  private readonly cache = new Map<number, WeightHistory>();
 
-  async getWeight(period = 0): Promise<WeightMeasurement[]> {
+  async getWeight(period = 0): Promise<WeightHistory> {
     const cached = this.cache.get(period);
     if (cached) {
       return cached;
@@ -27,11 +37,19 @@ export class WeightService {
     await this.withingsService.sync();
     const url = period ? `/api/weight?period=${period}` : '/api/weight';
     try {
-      const measurements = await fetchJson<WeightMeasurement[]>(this.http, url);
-      const result = measurements.map((measurement) => ({
-        ...measurement,
-        date: new Date(measurement.date),
-      }));
+      const response = await fetchJson<WeightHistoryResponse>(this.http, url);
+      const result: WeightHistory = {
+        measurements: response.measurements.map((measurement) => ({
+          ...measurement,
+          date: new Date(measurement.date),
+        })),
+        ...(response.baseline && {
+          baseline: {
+            ...response.baseline,
+            date: new Date(response.baseline.date),
+          },
+        }),
+      };
       this.cache.set(period, result);
       return result;
     } catch (e) {
@@ -45,7 +63,7 @@ export class WeightService {
   }
 
   async getTodayWeight(): Promise<WeightMeasurement | undefined> {
-    const measurements = await this.getWeight(1);
+    const { measurements } = await this.getWeight(1);
     return measurements.at(-1);
   }
 }

--- a/client/src/mocks/weight.ts
+++ b/client/src/mocks/weight.ts
@@ -5,15 +5,21 @@ export const weightMocks = [
   http.get('/api/weight', ({ request }) => {
     const url = new URL(request.url);
     const period = parseInt(url.searchParams.get('period') ?? '0');
+
+    if (!period) {
+      return HttpResponse.json({ measurements: weightMeasurements });
+    }
+
     const today = weightMeasurements.slice(-1)[0].date;
     const cutDate = today.getTime() - period * 1000 * 60 * 60 * 24;
-
-    return HttpResponse.json(
-      period
-        ? weightMeasurements.filter(
-            ({ date }) => period === 0 || date.getTime() >= cutDate
-          )
-        : weightMeasurements
+    const measurements = weightMeasurements.filter(
+      ({ date }) => date.getTime() >= cutDate
     );
+    const beforeRange = weightMeasurements.filter(
+      ({ date }) => date.getTime() < cutDate
+    );
+    const baseline = beforeRange[beforeRange.length - 1];
+
+    return HttpResponse.json({ measurements, ...(baseline && { baseline }) });
   }),
 ];

--- a/server/src/main/java/mucsi96/traininglog/weight/WeightController.java
+++ b/server/src/main/java/mucsi96/traininglog/weight/WeightController.java
@@ -1,7 +1,6 @@
 package mucsi96.traininglog.weight;
 
 import java.time.ZoneId;
-import java.util.List;
 import java.util.Optional;
 
 import org.springframework.http.MediaType;
@@ -15,6 +14,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
+import mucsi96.traininglog.api.WeightHistory;
 import mucsi96.traininglog.api.WeightMeasurement;
 
 @RestController
@@ -26,15 +26,22 @@ public class WeightController {
   private final WeightService weightService;
 
   @GetMapping
-  List<WeightMeasurement> weight(
+  WeightHistory weight(
       @RequestParam(required = false) @Positive Integer period,
       @RequestHeader("X-Timezone") ZoneId zoneId) {
-    return weightService.getWeight(Optional.ofNullable(period), zoneId).stream().map(measurement -> WeightMeasurement
-        .builder()
+    WeightService.WeightHistory history = weightService.getWeight(Optional.ofNullable(period), zoneId);
+    return WeightHistory.builder()
+        .measurements(history.measurements().stream().map(measurement -> toMeasurement(measurement, zoneId)).toList())
+        .baseline(history.baseline().map(measurement -> toMeasurement(measurement, zoneId)).orElse(null))
+        .build();
+  }
+
+  private WeightMeasurement toMeasurement(Weight measurement, ZoneId zoneId) {
+    return WeightMeasurement.builder()
         .date(measurement.getCreatedAt().withZoneSameInstant(zoneId).toOffsetDateTime())
         .weight(measurement.getWeight())
         .fatRatio(measurement.getFatRatio())
         .fatMassWeight(measurement.getFatMassWeight())
-        .build()).toList();
+        .build();
   }
 }

--- a/server/src/main/java/mucsi96/traininglog/weight/WeightRepository.java
+++ b/server/src/main/java/mucsi96/traininglog/weight/WeightRepository.java
@@ -2,6 +2,7 @@ package mucsi96.traininglog.weight;
 
 import java.time.ZonedDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,4 +10,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface WeightRepository extends JpaRepository<Weight, ZonedDateTime> {
   List<Weight> findByCreatedAtBetween(ZonedDateTime startTime, ZonedDateTime endTime, Sort sort);
   List<Weight> findByCreatedAtBefore(ZonedDateTime endTime, Sort sort);
+  Optional<Weight> findFirstByCreatedAtBeforeOrderByCreatedAtDesc(ZonedDateTime startTime);
 }

--- a/server/src/main/java/mucsi96/traininglog/weight/WeightService.java
+++ b/server/src/main/java/mucsi96/traininglog/weight/WeightService.java
@@ -20,20 +20,27 @@ public class WeightService {
   private final WeightRepository weightRepository;
   private final Clock clock;
 
+  public record WeightHistory(List<Weight> measurements, Optional<Weight> baseline) {
+  }
+
   public void saveWeight(Weight weight) {
     log.info("persisting weight in db with value {}", weight.getWeight());
     weightRepository.save(weight);
   }
 
-  public List<Weight> getWeight(Optional<Integer> period, ZoneId zoneId) {
+  public WeightHistory getWeight(Optional<Integer> period, ZoneId zoneId) {
     ZonedDateTime endTime = ZonedDateTime.now(clock).withZoneSameInstant(zoneId).truncatedTo(ChronoUnit.DAYS).plusDays(1);
     return period.map(days -> {
       ZonedDateTime startTime = ZonedDateTime.now(clock).withZoneSameInstant(zoneId).truncatedTo(ChronoUnit.DAYS).minusDays(days - 1);
       log.info("Getting weight measurements from {} to {}", startTime, endTime);
-      return weightRepository.findByCreatedAtBetween(startTime, endTime, Sort.by(Sort.Direction.ASC, "createdAt"));
+      List<Weight> measurements = weightRepository.findByCreatedAtBetween(startTime, endTime, Sort.by(Sort.Direction.ASC, "createdAt"));
+      Optional<Weight> baseline = weightRepository.findFirstByCreatedAtBeforeOrderByCreatedAtDesc(startTime);
+      return new WeightHistory(measurements, baseline);
     }).orElseGet(() -> {
       log.info("Getting weight measurements before {}", endTime);
-      return weightRepository.findByCreatedAtBefore(endTime, Sort.by(Sort.Direction.ASC, "createdAt"));
+      return new WeightHistory(
+          weightRepository.findByCreatedAtBefore(endTime, Sort.by(Sort.Direction.ASC, "createdAt")),
+          Optional.empty());
     });
   }
 }

--- a/server/src/main/resources/api.yml
+++ b/server/src/main/resources/api.yml
@@ -16,26 +16,17 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  title: WeightMeasurement
-                  type: object
-                  required:
-                    - date
-                    - weight
-                  properties:
-                    date:
-                      type: string
-                      format: date-time
-                    weight:
-                      type: number
-                      format: float
-                    fatRatio:
-                      type: number
-                      format: float
-                    fatMassWeight:
-                      type: number
-                      format: float
+                title: WeightHistory
+                type: object
+                required:
+                  - measurements
+                properties:
+                  measurements:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/WeightMeasurement'
+                  baseline:
+                    $ref: '#/components/schemas/WeightMeasurement'
 
   /ride/stats:
     get:
@@ -349,6 +340,24 @@ paths:
 
 components:
   schemas:
+    WeightMeasurement:
+      type: object
+      required:
+        - date
+        - weight
+      properties:
+        date:
+          type: string
+          format: date-time
+        weight:
+          type: number
+          format: float
+        fatRatio:
+          type: number
+          format: float
+        fatMassWeight:
+          type: number
+          format: float
     PushupSet:
       type: object
       required:

--- a/test/tests/weight.spec.ts
+++ b/test/tests/weight.spec.ts
@@ -24,29 +24,13 @@ test.describe('Weight', () => {
   test('should display weight diff for week', async ({ page }) => {
     await page.goto('/');
     await expect(page.getByRole('heading', { name: 'Weight' })).toBeVisible();
-    await expect(page.getByText('↓ 1.2 %')).toBeVisible();
-    await expect(page.getByText('↓ 27.8 %')).toBeVisible();
-    await expect(page.getByText('↑ 3.2 %')).toBeVisible();
+    await expect(page.getByText('↓ 2.5 %')).toBeVisible();
+    await expect(page.getByText('↓ 29.2 %')).toBeVisible();
+    await expect(page.getByText('↑ 2.3 %')).toBeVisible();
   });
 
   test('should display weight chart for week', async ({ page }) => {
     await page.goto('/');
-    await expect(page.getByRole('heading', { name: 'Weight' })).toBeVisible();
-    const chart = page.locator('section:has-text("Weight") [role="img"]');
-    await expect(chart).toHaveAttribute('aria-label', /This is a chart with type Line chart/);
-    const label = await chart.getAttribute('aria-label');
-    expect(label).toContain('88.3,');
-    expect(label).toContain('87.7,');
-    expect(label).toContain('87.5,');
-    expect(label).toContain('87.2.');
-    expect(label).not.toContain('108.9,');
-    expect(label).not.toContain('98,');
-    expect(label).not.toContain('89.4,');
-  });
-
-  test('should display weight chart for month', async ({ page }) => {
-    await page.goto('/');
-    await page.getByRole('link', { name: 'Month' }).click();
     await expect(page.getByRole('heading', { name: 'Weight' })).toBeVisible();
     const chart = page.locator('section:has-text("Weight") [role="img"]');
     await expect(chart).toHaveAttribute('aria-label', /This is a chart with type Line chart/);
@@ -60,9 +44,18 @@ test.describe('Weight', () => {
     expect(label).not.toContain('98,');
   });
 
-  test('should display weight chart for year', async ({ page }) => {
+  test('should display weight diff for month', async ({ page }) => {
     await page.goto('/');
-    await page.getByRole('link', { name: 'Year' }).click();
+    await page.getByRole('link', { name: 'Month' }).click();
+    await expect(page.getByRole('heading', { name: 'Weight' })).toBeVisible();
+    await expect(page.getByText('↓ 11 %')).toBeVisible();
+    await expect(page.getByText('↓ 36.8 %')).toBeVisible();
+    await expect(page.getByText('↑ 0.3 %')).toBeVisible();
+  });
+
+  test('should display weight chart for month', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('link', { name: 'Month' }).click();
     await expect(page.getByRole('heading', { name: 'Weight' })).toBeVisible();
     const chart = page.locator('section:has-text("Weight") [role="img"]');
     await expect(chart).toHaveAttribute('aria-label', /This is a chart with type Line chart/);
@@ -74,6 +67,31 @@ test.describe('Weight', () => {
     expect(label).toContain('87.5,');
     expect(label).toContain('87.2.');
     expect(label).not.toContain('108.9,');
+  });
+
+  test('should display weight diff for year', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('link', { name: 'Year' }).click();
+    await expect(page.getByRole('heading', { name: 'Weight' })).toBeVisible();
+    await expect(page.getByText('↓ 19.9 %')).toBeVisible();
+    await expect(page.getByText('↓ 43.5 %')).toBeVisible();
+    await expect(page.getByText('↓ 0.3 %')).toBeVisible();
+  });
+
+  test('should display weight chart for year', async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('link', { name: 'Year' }).click();
+    await expect(page.getByRole('heading', { name: 'Weight' })).toBeVisible();
+    const chart = page.locator('section:has-text("Weight") [role="img"]');
+    await expect(chart).toHaveAttribute('aria-label', /This is a chart with type Line chart/);
+    const label = await chart.getAttribute('aria-label');
+    expect(label).toContain('108.9,');
+    expect(label).toContain('98,');
+    expect(label).toContain('89.4,');
+    expect(label).toContain('88.3,');
+    expect(label).toContain('87.7,');
+    expect(label).toContain('87.5,');
+    expect(label).toContain('87.2.');
   });
 
   test('should display weight diff for all time', async ({ page }) => {
@@ -117,6 +135,7 @@ test.describe('Weight without a measurement today', () => {
     const chart = page.locator('section:has-text("Weight") [role="img"]').first();
     await expect(chart).toHaveAttribute('aria-label', /This is a chart with type Line chart/);
     const label = await chart.getAttribute('aria-label');
+    expect(label).toContain('89.4,');
     expect(label).toContain('88.3,');
     expect(label).toContain('87.7,');
     expect(label).toContain('87.5');


### PR DESCRIPTION
## Summary
This change refactors the weight API to return a `WeightHistory` object containing both current period measurements and an optional baseline measurement from before the period. This enables the UI to display weight differences relative to a baseline point rather than just the first measurement in the period.

## Key Changes

- **API Schema**: Modified `/api/weight` response to return a `WeightHistory` object with `measurements` array and optional `baseline` measurement instead of a flat array
- **Backend Service**: Updated `WeightService.getWeight()` to return a `WeightHistory` record containing measurements for the requested period and an optional baseline (the last measurement before the period starts)
- **Repository**: Added `findFirstByCreatedAtBeforeOrderByCreatedAtDesc()` query method to fetch the baseline measurement
- **Controller**: Updated `WeightController` to map the service response to the new API schema
- **Frontend Service**: Updated `WeightService.getWeight()` to handle the new response structure and cache `WeightHistory` instead of arrays
- **Component**: Refactored `WeightComponent` to use baseline for diff calculations when available, and include baseline in chart data for visual context
- **Tests**: Updated weight tests with new expected values and added new test cases for month and year periods

## Implementation Details

- The baseline is calculated as the most recent weight measurement before the requested period starts
- When no period is specified (all-time view), no baseline is returned
- The component now displays weight differences relative to the baseline when available, providing more meaningful comparisons across different time periods
- Chart visualization includes the baseline point to show the starting reference point for the period

https://claude.ai/code/session_012xHTFY3xH2VoXKgPAtooy2