### PR TITLE
Fix pushups chart to show continuous date range

### DIFF
--- a/client/src/app/pushups/pushups.component.ts
+++ b/client/src/app/pushups/pushups.component.ts
@@ -75,15 +75,41 @@ export class PushupsComponent {
       totalsByDay.set(day, (totalsByDay.get(day) ?? 0) + set.count);
     }
 
-    const data = [...totalsByDay.entries()]
-      .sort(([a], [b]) => a.localeCompare(b))
-      .map(([day, total]) => [new Date(day), total]);
+    const period = this.period() ?? 0;
+    const sortedDays = [...totalsByDay.keys()].sort();
+
+    const endDay = new Date();
+    endDay.setUTCHours(0, 0, 0, 0);
+
+    const startDay = new Date(endDay);
+    if (period > 0) {
+      startDay.setUTCDate(startDay.getUTCDate() - period + 1);
+    } else if (sortedDays.length > 0) {
+      startDay.setTime(new Date(sortedDays[0]).getTime());
+    }
+
+    const data: Array<[Date, number | null]> = [];
+    for (
+      const current = new Date(startDay);
+      current.getTime() <= endDay.getTime();
+      current.setUTCDate(current.getUTCDate() + 1)
+    ) {
+      const day = current.toISOString().slice(0, 10);
+      data.push([new Date(current), totalsByDay.get(day) ?? null]);
+    }
+
+    const dayMs = 24 * 3600 * 1000;
 
     return {
       aria: { enabled: true },
       animation: false,
       grid: { top: 10, right: 10, bottom: 10, left: 10 },
-      xAxis: { type: 'time', show: false },
+      xAxis: {
+        type: 'time',
+        show: false,
+        min: startDay.getTime() - dayMs / 2,
+        max: endDay.getTime() + dayMs / 2,
+      },
       yAxis: { type: 'value', show: false, min: 0 },
       series: [
         {


### PR DESCRIPTION
## Summary
Updated the pushups chart data generation to display a continuous date range instead of only showing days with recorded data. This ensures the chart properly visualizes gaps in workout history.

## Key Changes
- Modified data aggregation to generate entries for every day in the selected period, using `null` for days without pushup data
- Added period-based date range calculation:
  - If a period is set, the chart shows that many days from today
  - If no period is set, the chart shows from the first recorded day to today
- Updated x-axis configuration to explicitly set min/max bounds with half-day padding for proper chart alignment
- Changed data structure to `Array<[Date, number | null]>` to accommodate missing data points

## Implementation Details
- Uses UTC date operations for consistent date handling across timezones
- Iterates through each day in the range, looking up totals from the aggregated map
- Adds `dayMs` padding (half day on each side) to x-axis bounds to prevent data points from appearing at chart edges

https://claude.ai/code/session_01FN7Gx4hp4CDmctHvPLFuWy