### PR TITLE
Allow setting a starting page when adding a book

### DIFF
--- a/client/src/app/reading/reading-library.component.html
+++ b/client/src/app/reading/reading-library.component.html
@@ -98,6 +98,21 @@
           required
         />
       </mat-form-field>
+      <mat-form-field appearance="outline">
+        <mat-label>Starting page</mat-label>
+        <input
+          matInput
+          name="startingPage"
+          type="number"
+          min="0"
+          [ngModel]="draft().startingPage"
+          (ngModelChange)="updateDraft('startingPage', $event)"
+        />
+        <mat-hint
+          >Pages already read before tracking. Does not affect reading
+          pace.</mat-hint
+        >
+      </mat-form-field>
       <div class="actions">
         <button
           mat-stroked-button

--- a/client/src/app/reading/reading-library.component.ts
+++ b/client/src/app/reading/reading-library.component.ts
@@ -11,6 +11,7 @@ type NewBookDraft = {
   title: string;
   author: string;
   totalPages: number | null;
+  startingPage: number | null;
 };
 
 @Component({
@@ -32,7 +33,12 @@ export class ReadingLibraryComponent {
 
   readonly busy = signal(false);
   readonly addingBook = signal(false);
-  readonly draft = signal<NewBookDraft>({ title: '', author: '', totalPages: null });
+  readonly draft = signal<NewBookDraft>({
+    title: '',
+    author: '',
+    totalPages: null,
+    startingPage: null,
+  });
 
   readonly books = resource({
     params: () => this.readingService.version(),
@@ -48,17 +54,20 @@ export class ReadingLibraryComponent {
 
   readonly canSubmit = computed(() => {
     const d = this.draft();
+    const startingPage = d.startingPage ?? 0;
     return (
       !this.busy() &&
       d.title.trim().length > 0 &&
       d.author.trim().length > 0 &&
       typeof d.totalPages === 'number' &&
-      d.totalPages > 0
+      d.totalPages > 0 &&
+      startingPage >= 0 &&
+      startingPage < d.totalPages
     );
   });
 
   startAddingBook() {
-    this.draft.set({ title: '', author: '', totalPages: null });
+    this.draft.set({ title: '', author: '', totalPages: null, startingPage: null });
     this.addingBook.set(true);
   }
 
@@ -78,7 +87,8 @@ export class ReadingLibraryComponent {
       await this.readingService.addBook(
         d.title.trim(),
         d.author.trim(),
-        d.totalPages as number
+        d.totalPages as number,
+        d.startingPage ?? 0
       );
       this.addingBook.set(false);
     } finally {

--- a/client/src/app/reading/reading.component.html
+++ b/client/src/app/reading/reading.component.html
@@ -62,7 +62,7 @@
           <input
             matInput
             type="number"
-            min="0"
+            [min]="book.startingPage"
             [max]="book.totalPages"
             [value]="pageInputValue(book)"
             (input)="setPageInput(book, +$any($event.target).value)"

--- a/client/src/app/reading/reading.component.ts
+++ b/client/src/app/reading/reading.component.ts
@@ -61,7 +61,7 @@ export class ReadingComponent {
   async saveProgress(book: Book) {
     const value = this.pageInputValue(book);
     if (this.busy() || value === book.currentPage) return;
-    if (value < 0 || value > book.totalPages) return;
+    if (value < book.startingPage || value > book.totalPages) return;
     this.busy.set(true);
     try {
       await this.readingService.updateProgress(book.id, value);

--- a/client/src/app/reading/reading.service.ts
+++ b/client/src/app/reading/reading.service.ts
@@ -8,6 +8,7 @@ export type Book = {
   title: string;
   author: string;
   totalPages: number;
+  startingPage: number;
   currentPage: number;
   createdAt: Date;
   startedAt?: Date;
@@ -21,6 +22,7 @@ type BookDto = {
   title: string;
   author: string;
   totalPages: number;
+  startingPage: number;
   currentPage: number;
   createdAt: string;
   startedAt?: string;
@@ -67,11 +69,16 @@ export class ReadingService {
     }
   }
 
-  async addBook(title: string, author: string, totalPages: number): Promise<Book> {
+  async addBook(
+    title: string,
+    author: string,
+    totalPages: number,
+    startingPage: number
+  ): Promise<Book> {
     try {
       const book = await fetchJson<BookDto>(this.http, '/api/reading/books', {
         method: 'post',
-        body: { title, author, totalPages },
+        body: { title, author, totalPages, startingPage },
       });
       this.version.update((v) => v + 1);
       return toBook(book);

--- a/server/src/main/java/mucsi96/traininglog/reading/BookEntity.java
+++ b/server/src/main/java/mucsi96/traininglog/reading/BookEntity.java
@@ -31,6 +31,9 @@ public class BookEntity {
   @Column(name = "total_pages", nullable = false)
   private int totalPages;
 
+  @Column(name = "starting_page", nullable = false)
+  private int startingPage;
+
   @Column(name = "created_at", nullable = false)
   private ZonedDateTime createdAt;
 

--- a/server/src/main/java/mucsi96/traininglog/reading/ReadingController.java
+++ b/server/src/main/java/mucsi96/traininglog/reading/ReadingController.java
@@ -46,8 +46,9 @@ public class ReadingController {
   @PostMapping(value = "/books", consumes = MediaType.APPLICATION_JSON_VALUE)
   @PreAuthorize("hasAuthority('APPROLE_WorkoutCreator') and hasAuthority('SCOPE_createWorkout')")
   Book addBook(@Valid @RequestBody AddBookRequest request, @RequestHeader("X-Timezone") ZoneId zoneId) {
+    int startingPage = request.getStartingPage() == null ? 0 : request.getStartingPage();
     BookSummary saved = readingService.addBook(
-        request.getTitle().trim(), request.getAuthor().trim(), request.getTotalPages());
+        request.getTitle().trim(), request.getAuthor().trim(), request.getTotalPages(), startingPage);
     return toResponse(saved, zoneId);
   }
 
@@ -85,6 +86,7 @@ public class ReadingController {
         .title(book.getTitle())
         .author(book.getAuthor())
         .totalPages(book.getTotalPages())
+        .startingPage(book.getStartingPage())
         .currentPage(book.getCurrentPage())
         .createdAt(book.getCreatedAt().withZoneSameInstant(zoneId).toOffsetDateTime())
         .startedAt(book.getStartedAt() == null
@@ -110,6 +112,9 @@ public class ReadingController {
     @Min(1)
     @Max(100000)
     private Integer totalPages;
+    @Min(0)
+    @Max(100000)
+    private Integer startingPage;
   }
 
   @Data

--- a/server/src/main/java/mucsi96/traininglog/reading/ReadingService.java
+++ b/server/src/main/java/mucsi96/traininglog/reading/ReadingService.java
@@ -7,7 +7,6 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -38,15 +37,21 @@ public class ReadingService {
   private final Clock clock;
 
   @Transactional
-  public BookSummary addBook(String title, String author, int totalPages) {
+  public BookSummary addBook(String title, String author, int totalPages, int startingPage) {
+    if (startingPage < 0 || startingPage >= totalPages) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+          "startingPage must be between 0 and " + (totalPages - 1));
+    }
     BookEntity book = BookEntity.builder()
         .id(UUID.randomUUID())
         .title(title)
         .author(author)
         .totalPages(totalPages)
+        .startingPage(startingPage)
         .createdAt(now())
         .build();
-    log.info("persisting book {} by {} with {} pages", title, author, totalPages);
+    log.info("persisting book {} by {} with {} pages (starting at {})",
+        title, author, totalPages, startingPage);
     return toSummary(bookRepository.save(book), List.of());
   }
 
@@ -54,9 +59,9 @@ public class ReadingService {
   public BookSummary updateProgress(UUID bookId, int currentPage) {
     BookEntity book = bookRepository.findById(bookId)
         .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Book not found"));
-    if (currentPage < 0 || currentPage > book.getTotalPages()) {
+    if (currentPage < book.getStartingPage() || currentPage > book.getTotalPages()) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
-          "currentPage must be between 0 and " + book.getTotalPages());
+          "currentPage must be between " + book.getStartingPage() + " and " + book.getTotalPages());
     }
     ZonedDateTime timestamp = now();
     progressRepository.save(ReadingProgressEntity.builder()
@@ -111,9 +116,10 @@ public class ReadingService {
 
   @Transactional(readOnly = true)
   public Map<LocalDate, Integer> getPagesReadByDay(ZoneId zoneId) {
+    Map<UUID, Integer> lastSeen = bookRepository.findAll().stream()
+        .collect(Collectors.toMap(BookEntity::getId, BookEntity::getStartingPage));
     List<ReadingProgressEntity> all = progressRepository
         .findAll(Sort.by(Sort.Direction.ASC, "createdAt"));
-    Map<UUID, Integer> lastSeen = new HashMap<>();
     Map<LocalDate, Integer> pagesByDay = new TreeMap<>();
     for (ReadingProgressEntity entry : all) {
       int previous = lastSeen.getOrDefault(entry.getBookId(), 0);
@@ -134,17 +140,19 @@ public class ReadingService {
   private BookSummary toSummary(BookEntity book, List<ReadingProgressEntity> progress) {
     Optional<ReadingProgressEntity> latest = progress.stream()
         .max(Comparator.comparing(ReadingProgressEntity::getCreatedAt));
-    int currentPage = latest.map(ReadingProgressEntity::getCurrentPage).orElse(0);
+    int currentPage = latest.map(ReadingProgressEntity::getCurrentPage)
+        .orElse(book.getStartingPage());
     Optional<ZonedDateTime> startedAt = progress.stream()
         .map(ReadingProgressEntity::getCreatedAt)
         .min(Comparator.naturalOrder());
 
     Double averagePagesPerDay = null;
     Integer estimatedDaysRemaining = null;
-    if (startedAt.isPresent() && currentPage > 0) {
+    int pagesReadSinceStart = currentPage - book.getStartingPage();
+    if (startedAt.isPresent() && pagesReadSinceStart > 0) {
       long daysElapsed = Math.max(1,
           ChronoUnit.DAYS.between(startedAt.get().toLocalDate(), now().toLocalDate()) + 1);
-      double avg = (double) currentPage / daysElapsed;
+      double avg = (double) pagesReadSinceStart / daysElapsed;
       averagePagesPerDay = avg;
       int remainingPages = Math.max(0, book.getTotalPages() - currentPage);
       if (remainingPages == 0) {
@@ -159,6 +167,7 @@ public class ReadingService {
         .title(book.getTitle())
         .author(book.getAuthor())
         .totalPages(book.getTotalPages())
+        .startingPage(book.getStartingPage())
         .currentPage(currentPage)
         .createdAt(book.getCreatedAt())
         .startedAt(startedAt.orElse(null))
@@ -175,6 +184,7 @@ public class ReadingService {
     private String title;
     private String author;
     private int totalPages;
+    private int startingPage;
     private int currentPage;
     private ZonedDateTime createdAt;
     private ZonedDateTime startedAt;

--- a/server/src/main/resources/api.yml
+++ b/server/src/main/resources/api.yml
@@ -263,6 +263,10 @@ paths:
                   type: integer
                   minimum: 1
                   maximum: 100000
+                startingPage:
+                  type: integer
+                  minimum: 0
+                  maximum: 100000
       responses:
         '200':
           description: OK
@@ -398,6 +402,7 @@ components:
         - title
         - author
         - totalPages
+        - startingPage
         - currentPage
         - createdAt
       properties:
@@ -409,6 +414,9 @@ components:
         author:
           type: string
         totalPages:
+          type: integer
+          format: int32
+        startingPage:
           type: integer
           format: int32
         currentPage:

--- a/server/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/server/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -468,3 +468,17 @@ databaseChangeLog:
             dbms: postgresql
             sql: |
               UPDATE training_log.golden_day SET celebrated_at = created_at WHERE celebrated_at IS NULL;
+
+  - changeSet:
+      id: 15-add-starting-page-to-book
+      author: mucsi96
+      changes:
+        - addColumn:
+            tableName: book
+            columns:
+              - column:
+                  name: starting_page
+                  type: integer
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false

--- a/test/tests/reading.spec.ts
+++ b/test/tests/reading.spec.ts
@@ -93,6 +93,10 @@ test.describe('Reading', () => {
     await library.getByLabel('Starting page').fill('80');
     await library.getByRole('button', { name: 'Add book' }).click();
 
+    await expect(
+      library.getByRole('heading', { name: 'Already Started' })
+    ).toBeVisible();
+
     const books = await getBookRows();
     expect(books).toHaveLength(1);
     expect(books[0].starting_page).toBe(80);

--- a/test/tests/reading.spec.ts
+++ b/test/tests/reading.spec.ts
@@ -73,11 +73,83 @@ test.describe('Reading', () => {
     expect(books[0].title).toBe('The Pragmatic Programmer');
     expect(books[0].author).toBe('David Thomas');
     expect(books[0].total_pages).toBe(320);
+    expect(books[0].starting_page).toBe(0);
 
     await page.goto('/');
     const section = page.getByRole('region', { name: 'Reading' });
     await expect(
       section.getByRole('heading', { name: 'The Pragmatic Programmer' })
+    ).toBeVisible();
+  });
+
+  test('adds a book with a starting page already read', async ({ page }) => {
+    await page.goto('/settings');
+    const library = page.getByRole('region', { name: 'Books' });
+
+    await library.getByRole('button', { name: 'Add book' }).click();
+    await library.getByLabel('Title').fill('Already Started');
+    await library.getByLabel('Author').fill('Author');
+    await library.getByLabel('Total pages').fill('300');
+    await library.getByLabel('Starting page').fill('80');
+    await library.getByRole('button', { name: 'Add book' }).click();
+
+    const books = await getBookRows();
+    expect(books).toHaveLength(1);
+    expect(books[0].starting_page).toBe(80);
+    expect(books[0].total_pages).toBe(300);
+
+    await page.goto('/');
+    const section = page.getByRole('region', { name: 'Reading' });
+    await expect(
+      section.getByRole('article', { name: /Already Started, 80 of 300 pages/ })
+    ).toBeVisible();
+  });
+
+  test('starting page acts as baseline and does not inflate reading pace', async ({
+    page,
+  }) => {
+    const bookId = randomUUID();
+    await insertBook(
+      bookId,
+      'Resumed Book',
+      'Author',
+      300,
+      daysAgoAt(4, 8),
+      null,
+      100
+    );
+    await insertReadingProgress(bookId, 100, daysAgoAt(4, 8));
+    await insertReadingProgress(bookId, 140, daysAgoAt(0, 12));
+
+    await page.goto('/');
+    const section = page.getByRole('region', { name: 'Reading' });
+    await expect(
+      section.getByRole('article', { name: /Resumed Book, 140 of 300 pages/ })
+    ).toBeVisible();
+    await expect(section.getByText('8.0 pages/day avg')).toBeVisible();
+    await expect(section.getByText('About 20 days to finish')).toBeVisible();
+  });
+
+  test('only counts pages read past the starting page toward the daily goal', async ({
+    page,
+  }) => {
+    await setGoldenDayGoal(100, 250, 30);
+    const bookId = randomUUID();
+    await insertBook(
+      bookId,
+      'Resumed Book',
+      'Author',
+      300,
+      daysAgoAt(1, 8),
+      null,
+      100
+    );
+    await insertReadingProgress(bookId, 115, daysAgoAt(0, 12));
+
+    await page.goto('/');
+    const section = page.getByRole('region', { name: 'Reading' });
+    await expect(
+      section.getByRole('img', { name: '15 of 30 pages today' })
     ).toBeVisible();
   });
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -217,11 +217,12 @@ export async function insertBook(
   author: string,
   totalPages: number,
   createdAt: Date = new Date(),
-  completedAt: Date | null = null
+  completedAt: Date | null = null,
+  startingPage: number = 0
 ) {
   await query(
-    'INSERT INTO training_log.book (id, title, author, total_pages, created_at, completed_at) VALUES ($1, $2, $3, $4, $5, $6)',
-    [id, title, author, totalPages, createdAt, completedAt]
+    'INSERT INTO training_log.book (id, title, author, total_pages, starting_page, created_at, completed_at) VALUES ($1, $2, $3, $4, $5, $6, $7)',
+    [id, title, author, totalPages, startingPage, createdAt, completedAt]
   );
 }
 
@@ -238,7 +239,7 @@ export async function insertReadingProgress(
 
 export async function getBookRows() {
   const result = await query(
-    'SELECT id, title, author, total_pages, completed_at FROM training_log.book ORDER BY created_at ASC'
+    'SELECT id, title, author, total_pages, starting_page, completed_at FROM training_log.book ORDER BY created_at ASC'
   );
   return result.rows;
 }


### PR DESCRIPTION
The starting page is treated as already-read baseline so the reading
pace and finish estimate only reflect pages read since tracking began.