### PR TITLE
Show today diff inline and period diff as plain blue text

### DIFF
--- a/client/src/app/weight/weight.component.css
+++ b/client/src/app/weight/weight.component.css
@@ -26,18 +26,28 @@ h2 {
   color: var(--mat-sys-on-primary);
   font-size: 24px;
   font-weight: 700;
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  flex-wrap: wrap;
 }
 
-.diff-value {
+.today-diff {
   font-size: 14px;
+  font-weight: 400;
 }
 
-.diff-value.green {
+.today-diff.green {
   color: hsl(111, 32%, 66%);
 }
 
-.diff-value.red {
+.today-diff.red {
   color: hsl(0, 91%, 74%);
+}
+
+.period-value {
+  color: var(--mat-sys-primary);
+  font-size: 14px;
 }
 
 .chart-wrapper {

--- a/client/src/app/weight/weight.component.html
+++ b/client/src/app/weight/weight.component.html
@@ -1,7 +1,8 @@
-@let today = todayWeight.value();
-@let diffVal = diff();
+@let todayVal = today();
+@let todayDiffVal = todayDiff();
+@let periodDiffVal = periodDiff();
 @let chart = chartOptions();
-@if (todayWeight.isLoading() || periodHistory.isLoading()) {
+@if (todayHistory.isLoading() || periodHistory.isLoading()) {
 <mat-spinner class="page-loading" />
 } @else if (chart) {
 <section>
@@ -14,32 +15,47 @@
       [initOpts]="initOpts"
     ></div>
   </div>
-  @if (today) {
+  @if (todayVal) {
   <article>
     <h2>Weight</h2>
     <p class="value">
-      {{ today.weight | measurementWithUnit : "kg" }}
+      <span>{{ todayVal.weight | measurementWithUnit : "kg" }}</span>
+      @if (todayDiffVal?.weight; as weightDiff) {
+      <span [class]="'today-diff ' + (weightDiff | diffColor : 'inverse')">
+        {{ weightDiff | absoluteDiff : "kg" }}
+      </span>
+      }
     </p>
-    <p [class]="'diff-value ' + (diffVal?.weight | diffColor : 'inverse')">
-      {{ diffVal?.weight | absoluteDiff : "kg" }}
+    <p class="period-value">
+      {{ periodDiffVal?.weight | absoluteDiff : "kg" }}
     </p>
   </article>
   <article>
     <h2>Body fat</h2>
     <p class="value">
-      {{ today.fatMassWeight | measurementWithUnit : "kg" }}
+      <span>{{ todayVal.fatMassWeight | measurementWithUnit : "kg" }}</span>
+      @if (todayDiffVal?.fatMassWeight; as fatMassDiff) {
+      <span [class]="'today-diff ' + (fatMassDiff | diffColor : 'inverse')">
+        {{ fatMassDiff | absoluteDiff : "kg" }}
+      </span>
+      }
     </p>
-    <p [class]="'diff-value ' + (diffVal?.fatMassWeight | diffColor : 'inverse')">
-      {{ diffVal?.fatMassWeight | absoluteDiff : "kg" }}
+    <p class="period-value">
+      {{ periodDiffVal?.fatMassWeight | absoluteDiff : "kg" }}
     </p>
   </article>
   <article>
     <h2>Fat ratio</h2>
     <p class="value">
-      {{ today.fatRatio | measurementWithUnit : "%" }}
+      <span>{{ todayVal.fatRatio | measurementWithUnit : "%" }}</span>
+      @if (todayDiffVal?.fatRatio; as fatRatioDiff) {
+      <span [class]="'today-diff ' + (fatRatioDiff | diffColor : 'inverse')">
+        {{ fatRatioDiff | absoluteDiff : "%" }}
+      </span>
+      }
     </p>
-    <p [class]="'diff-value ' + (diffVal?.fatRatio | diffColor : 'inverse')">
-      {{ diffVal?.fatRatio | absoluteDiff : "%" }}
+    <p class="period-value">
+      {{ periodDiffVal?.fatRatio | absoluteDiff : "%" }}
     </p>
   </article>
   }

--- a/client/src/app/weight/weight.component.ts
+++ b/client/src/app/weight/weight.component.ts
@@ -10,6 +10,29 @@ import { AbsoluteDiffPipe } from '../utils/absolute-diff.pipe';
 import { DiffColorPipe } from '../utils/diff-color.pipe';
 import { MeasurementWithUnitPipe } from '../utils/measurement-with-unit.pipe';
 
+type WeightDiff = {
+  weight: number;
+  fatMassWeight?: number;
+  fatRatio?: number;
+};
+
+function computeDiff(
+  initial: WeightMeasurement,
+  latest: WeightMeasurement,
+): WeightDiff {
+  return {
+    weight: latest.weight - initial.weight,
+    ...(initial.fatMassWeight &&
+      latest.fatMassWeight && {
+        fatMassWeight: latest.fatMassWeight - initial.fatMassWeight,
+      }),
+    ...(initial.fatRatio &&
+      latest.fatRatio && {
+        fatRatio: latest.fatRatio - initial.fatRatio,
+      }),
+  };
+}
+
 @Component({
   standalone: true,
   imports: [
@@ -31,7 +54,7 @@ export class WeightComponent {
 
   readonly initOpts = { renderer: 'svg' as const };
 
-  readonly todayWeight = resource({
+  readonly todayHistory = resource({
     loader: () => this.weightService.getTodayWeight(),
   });
 
@@ -40,7 +63,21 @@ export class WeightComponent {
     loader: ({ params: period }) => this.weightService.getWeight(period),
   });
 
-  readonly diff = computed(() => {
+  readonly today = computed<WeightMeasurement | undefined>(() => {
+    return this.todayHistory.value()?.measurements.at(-1);
+  });
+
+  readonly todayDiff = computed<WeightDiff | undefined>(() => {
+    const history = this.todayHistory.value();
+    const latest = history?.measurements.at(-1);
+    const previous = history?.baseline;
+    if (!history || !latest || !previous) {
+      return undefined;
+    }
+    return computeDiff(previous, latest);
+  });
+
+  readonly periodDiff = computed<WeightDiff | undefined>(() => {
     const history = this.periodHistory.value();
     if (!history || history.measurements.length === 0) {
       return undefined;
@@ -53,18 +90,7 @@ export class WeightComponent {
       return undefined;
     }
 
-    return {
-      date: latest.date,
-      weight: latest.weight - initial.weight,
-      ...(initial.fatMassWeight &&
-        latest.fatMassWeight && {
-          fatMassWeight: latest.fatMassWeight - initial.fatMassWeight,
-        }),
-      ...(initial.fatRatio &&
-        latest.fatRatio && {
-          fatRatio: latest.fatRatio - initial.fatRatio,
-        }),
-    };
+    return computeDiff(initial, latest);
   });
 
   readonly chartOptions = computed<EChartsOption | undefined>(() => {

--- a/client/src/app/weight/weight.service.ts
+++ b/client/src/app/weight/weight.service.ts
@@ -62,8 +62,7 @@ export class WeightService {
     }
   }
 
-  async getTodayWeight(): Promise<WeightMeasurement | undefined> {
-    const { measurements } = await this.getWeight(1);
-    return measurements.at(-1);
+  async getTodayWeight(): Promise<WeightHistory> {
+    return this.getWeight(1);
   }
 }

--- a/test/tests/weight.spec.ts
+++ b/test/tests/weight.spec.ts
@@ -21,6 +21,22 @@ test.describe('Weight', () => {
     await expect(page.getByText('35.3 %')).toBeVisible();
   });
 
+  test('should display today\'s diff inline with each value', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByRole('heading', { name: 'Weight' })).toBeVisible();
+    const weightArticle = page.locator('article', { hasText: 'Weight' });
+    await expect(weightArticle.locator('.today-diff')).toHaveText('↓ 0.3 kg');
+    await expect(weightArticle.locator('.today-diff')).toHaveClass(/green/);
+
+    const fatArticle = page.locator('article', { hasText: 'Body fat' });
+    await expect(fatArticle.locator('.today-diff')).toHaveText('↓ 7.2 kg');
+    await expect(fatArticle.locator('.today-diff')).toHaveClass(/green/);
+
+    const ratioArticle = page.locator('article', { hasText: 'Fat ratio' });
+    await expect(ratioArticle.locator('.today-diff')).toHaveText('↑ 2.5 %');
+    await expect(ratioArticle.locator('.today-diff')).toHaveClass(/red/);
+  });
+
   test('should display weight diff for week', async ({ page }) => {
     await page.goto('/');
     await expect(page.getByRole('heading', { name: 'Weight' })).toBeVisible();


### PR DESCRIPTION
Drop the labeled today/period diff style for weight, body fat, and
fat ratio. The today diff now sits next to the value with no label,
colored green or red. The selected range diff appears below in the
same blue style used for ride period totals.