### PR TITLE
Apply the same diff layout to fitness

### DIFF
--- a/client/src/app/fitness/fitness.component.css
+++ b/client/src/app/fitness/fitness.component.css
@@ -26,27 +26,28 @@ h2 {
   color: var(--mat-sys-on-primary);
   font-size: 24px;
   font-weight: 700;
-}
-
-.diff-value {
-  font-size: 14px;
   display: flex;
-  justify-content: space-between;
+  align-items: baseline;
   gap: 8px;
+  flex-wrap: wrap;
 }
 
-.diff-label {
-  color: var(--mat-app-text-color);
-  opacity: 0.7;
+.today-diff {
+  font-size: 14px;
   font-weight: 400;
 }
 
-.diff-value.green {
+.today-diff.green {
   color: hsl(111, 32%, 66%);
 }
 
-.diff-value.red {
+.today-diff.red {
   color: hsl(0, 91%, 74%);
+}
+
+.period-value {
+  color: var(--mat-sys-primary);
+  font-size: 14px;
 }
 
 .chart-wrapper {

--- a/client/src/app/fitness/fitness.component.html
+++ b/client/src/app/fitness/fitness.component.html
@@ -17,14 +17,16 @@
   </div>
   <article>
     <h2>Fitness</h2>
-    <p class="value">{{ value.fitness | number : "1.0-0" }}</p>
-    <p [class]="'diff-value ' + (todayDiffVal | diffColor)">
-      <span class="diff-label">Today</span>
-      <span>{{ todayDiffVal | pointsDiff }}</span>
+    <p class="value">
+      <span>{{ value.fitness | number : "1.0-0" }}</span>
+      @if (todayDiffVal) {
+      <span [class]="'today-diff ' + (todayDiffVal | diffColor)">
+        {{ todayDiffVal | pointsDiff }}
+      </span>
+      }
     </p>
-    <p [class]="'diff-value ' + (periodDiffVal | diffColor)">
-      <span class="diff-label">Period</span>
-      <span>{{ periodDiffVal | pointsDiff }}</span>
+    <p class="period-value">
+      {{ periodDiffVal | pointsDiff }}
     </p>
   </article>
 </section>

--- a/test/tests/fitness.spec.ts
+++ b/test/tests/fitness.spec.ts
@@ -18,15 +18,12 @@ test.describe('Fitness diff', () => {
     const fitnessSection = page.locator('section').filter({ hasText: 'Fitness' });
     await expect(fitnessSection.getByRole('heading', { name: 'Fitness' })).toBeVisible();
 
-    const todayRow = fitnessSection.locator('p', { hasText: 'Today' });
-    await expect(todayRow).toBeVisible();
-    await expect(todayRow).toHaveText(/Today.*↑/);
-    await expect(todayRow).toHaveClass(/green/);
+    const todayDiff = fitnessSection.locator('.today-diff');
+    await expect(todayDiff).toHaveText(/↑/);
+    await expect(todayDiff).toHaveClass(/green/);
 
-    const periodRow = fitnessSection.locator('p', { hasText: 'Period' });
-    await expect(periodRow).toBeVisible();
-    await expect(periodRow).toHaveText(/Period.*↑/);
-    await expect(periodRow).toHaveClass(/green/);
+    const periodValue = fitnessSection.locator('.period-value');
+    await expect(periodValue).toHaveText(/↑/);
   });
 
   test('shows a downward today diff when fitness decays without a ride', async ({ page }) => {
@@ -39,9 +36,9 @@ test.describe('Fitness diff', () => {
     const fitnessSection = page.locator('section').filter({ hasText: 'Fitness' });
     await expect(fitnessSection.getByRole('heading', { name: 'Fitness' })).toBeVisible();
 
-    const todayRow = fitnessSection.locator('p', { hasText: 'Today' });
-    await expect(todayRow).toHaveText(/Today.*↓/);
-    await expect(todayRow).toHaveClass(/red/);
+    const todayDiff = fitnessSection.locator('.today-diff');
+    await expect(todayDiff).toHaveText(/↓/);
+    await expect(todayDiff).toHaveClass(/red/);
   });
 
   test('shows period diff over the selected month timeframe', async ({ page }) => {
@@ -55,9 +52,8 @@ test.describe('Fitness diff', () => {
     const fitnessSection = page.locator('section').filter({ hasText: 'Fitness' });
     await expect(fitnessSection.getByRole('heading', { name: 'Fitness' })).toBeVisible();
 
-    const periodRow = fitnessSection.locator('p', { hasText: 'Period' });
-    await expect(periodRow).toHaveText(/Period.*↑/);
-    await expect(periodRow).toHaveClass(/green/);
+    const periodValue = fitnessSection.locator('.period-value');
+    await expect(periodValue).toHaveText(/↑/);
   });
 
   test('renders a placeholder when there is only one fitness measurement', async ({ page }) => {
@@ -69,9 +65,7 @@ test.describe('Fitness diff', () => {
     const fitnessSection = page.locator('section').filter({ hasText: 'Fitness' });
     await expect(fitnessSection.getByRole('heading', { name: 'Fitness' })).toBeVisible();
 
-    const todayRow = fitnessSection.locator('p', { hasText: 'Today' });
-    await expect(todayRow).toHaveText(/Today.*-/);
-    const periodRow = fitnessSection.locator('p', { hasText: 'Period' });
-    await expect(periodRow).toHaveText(/Period.*-/);
+    await expect(fitnessSection.locator('.today-diff')).toHaveCount(0);
+    await expect(fitnessSection.locator('.period-value')).toHaveText('-');
   });
 });


### PR DESCRIPTION
The today diff now appears next to the fitness value without a label and the selected range diff sits below in the shared blue style.