### PR TITLE
Redesign reading progress UI with dialog-based page input

### DIFF
--- a/client/src/app/circular-slider/circular-slider.component.ts
+++ b/client/src/app/circular-slider/circular-slider.component.ts
@@ -26,7 +26,8 @@ type Point = { x: number; y: number };
   host: {
     role: 'spinbutton',
     '[attr.aria-valuenow]': 'value()',
-    '[attr.aria-valuemin]': '0',
+    '[attr.aria-valuemin]': 'min()',
+    '[attr.aria-valuemax]': 'max()',
     '[attr.aria-valuetext]': 'ariaValueText()',
     '[attr.aria-label]': 'ariaLabel()',
     '[attr.tabindex]': 'disabled() ? -1 : 0',
@@ -42,6 +43,9 @@ export class CircularSliderComponent {
   readonly disabled = input(false);
   readonly trackWidth = input(28);
   readonly handleRadius = input(16);
+  readonly min = input(0);
+  readonly max = input<number | null>(null);
+  readonly unitLabel = input('pushups');
 
   readonly value = model.required<number>();
 
@@ -75,7 +79,7 @@ export class CircularSliderComponent {
   });
 
   readonly handlePoint = computed(() => this.angleToPoint(this.displayAngle()));
-  readonly ariaValueText = computed(() => `${this.value()} pushups`);
+  readonly ariaValueText = computed(() => `${this.value()} ${this.unitLabel()}`);
 
   constructor() {
     effect(() => {
@@ -111,8 +115,7 @@ export class CircularSliderComponent {
       delta += 360;
     }
     this.prevAngle = angle;
-    const next = Math.max(
-      0,
+    const next = this.clamp(
       this.accumulator() + (delta / 360) * this.unitsPerRevolution()
     );
     this.accumulator.set(next);
@@ -153,7 +156,7 @@ export class CircularSliderComponent {
         next = v - this.unitsPerRevolution();
         break;
       case 'Home':
-        next = 0;
+        next = this.min();
         break;
       default:
         return;
@@ -171,10 +174,16 @@ export class CircularSliderComponent {
   }
 
   private commit(next: number): void {
-    const clamped = Math.max(0, next);
+    const clamped = this.clamp(next);
     if (clamped !== this.value()) {
       this.value.set(clamped);
     }
+  }
+
+  private clamp(value: number): number {
+    const max = this.max();
+    const upperBound = max ?? Infinity;
+    return Math.min(upperBound, Math.max(this.min(), value));
   }
 
   private angleToPoint(angleDeg: number): Point {

--- a/client/src/app/reading/reading-progress-dialog.component.css
+++ b/client/src/app/reading/reading-progress-dialog.component.css
@@ -1,0 +1,28 @@
+.dialog-content {
+  display: grid;
+  justify-items: center;
+  gap: 12px;
+  padding-top: 8px;
+  min-width: 320px;
+}
+
+.author {
+  margin: 0;
+  color: var(--mat-app-text-color);
+  font-size: 13px;
+}
+
+.page-value {
+  color: var(--mat-sys-on-primary);
+  font-size: 56px;
+  font-weight: 700;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+
+.page-label {
+  color: var(--mat-app-text-color);
+  font-size: 13px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}

--- a/client/src/app/reading/reading-progress-dialog.component.html
+++ b/client/src/app/reading/reading-progress-dialog.component.html
@@ -1,0 +1,28 @@
+<h2 mat-dialog-title>{{ book.title }}</h2>
+<mat-dialog-content class="dialog-content">
+  <p class="author">{{ book.author }}</p>
+  <app-circular-slider
+    class="slider"
+    [(value)]="page"
+    [min]="book.startingPage"
+    [max]="book.totalPages"
+    [unitsPerRevolution]="25"
+    unitLabel="pages"
+    [ariaLabel]="ariaLabel"
+  >
+    <span class="page-value">{{ page() }}</span>
+    <span class="page-label">of {{ book.totalPages }}</span>
+  </app-circular-slider>
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-button type="button" (click)="cancel()">Cancel</button>
+  <button
+    mat-flat-button
+    color="primary"
+    type="button"
+    [disabled]="!canSave()"
+    (click)="save()"
+  >
+    Save {{ page() }}
+  </button>
+</mat-dialog-actions>

--- a/client/src/app/reading/reading-progress-dialog.component.ts
+++ b/client/src/app/reading/reading-progress-dialog.component.ts
@@ -1,0 +1,52 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogModule,
+  MatDialogRef,
+} from '@angular/material/dialog';
+import { CircularSliderComponent } from '../circular-slider/circular-slider.component';
+import { Book } from './reading.service';
+
+export type ReadingProgressDialogData = {
+  book: Book;
+};
+
+export type ReadingProgressDialogResult = number | null;
+
+@Component({
+  standalone: true,
+  selector: 'app-reading-progress-dialog',
+  imports: [MatButtonModule, MatDialogModule, CircularSliderComponent],
+  templateUrl: './reading-progress-dialog.component.html',
+  styleUrl: './reading-progress-dialog.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ReadingProgressDialogComponent {
+  private readonly dialogRef = inject<
+    MatDialogRef<ReadingProgressDialogComponent, ReadingProgressDialogResult>
+  >(MatDialogRef);
+  readonly data = inject<ReadingProgressDialogData>(MAT_DIALOG_DATA);
+
+  readonly book = this.data.book;
+  readonly page = signal(this.book.currentPage);
+  readonly canSave = computed(() => this.page() !== this.book.currentPage);
+  readonly ariaLabel = `Current page for ${this.book.title}`;
+
+  cancel(): void {
+    this.dialogRef.close(null);
+  }
+
+  save(): void {
+    if (!this.canSave()) {
+      return;
+    }
+    this.dialogRef.close(this.page());
+  }
+}

--- a/client/src/app/reading/reading.component.css
+++ b/client/src/app/reading/reading.component.css
@@ -1,6 +1,6 @@
 section {
   display: grid;
-  gap: 24px;
+  gap: 16px;
   justify-items: stretch;
 }
 
@@ -16,71 +16,9 @@ h2 {
   font-weight: 700;
 }
 
-.subtitle {
-  color: var(--mat-app-text-color);
-  font-size: 14px;
-}
-
-.ring-wrapper {
-  position: relative;
-  width: 220px;
-  height: 220px;
-  margin: 8px auto 0;
-}
-
-.ring {
-  width: 100%;
-  height: 100%;
-  transform: rotate(-90deg);
-}
-
-.ring-track,
-.ring-progress {
-  fill: none;
-  stroke-width: 10;
-  stroke-linecap: round;
-}
-
-.ring-track {
-  stroke: hsl(217, 19%, 27%);
-}
-
-.ring-progress {
-  stroke: var(--mat-sys-primary);
-  stroke-dasharray: 326.7;
-  transition: stroke-dashoffset 250ms ease-out, stroke 250ms ease-out;
-}
-
-.ring-progress--complete {
-  stroke: hsl(145, 78%, 55%);
-}
-
-.ring-content {
-  position: absolute;
-  inset: 0;
-  display: grid;
-  align-content: center;
-  justify-items: center;
-  gap: 2px;
-}
-
-.ring-count {
-  color: var(--mat-sys-on-primary);
-  font-size: 56px;
-  font-weight: 700;
-  line-height: 1;
-  font-variant-numeric: tabular-nums;
-}
-
-.ring-goal {
-  color: var(--mat-app-text-color);
-  font-size: 14px;
-  font-weight: 500;
-}
-
 .books {
   display: grid;
-  gap: 16px;
+  gap: 12px;
 }
 
 .empty {
@@ -90,40 +28,52 @@ h2 {
 }
 
 .book {
+  position: relative;
   display: grid;
   gap: 12px;
-  padding: 16px;
-  border-radius: 0.75rem;
-  background: var(--mat-sys-surface-container);
+  padding: 14px 16px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, hsl(217, 28%, 18%), hsl(217, 28%, 14%));
+  border: 1px solid hsl(217, 19%, 27%);
+  cursor: pointer;
+  overflow: hidden;
+  transition: border-color 180ms ease-out, transform 180ms ease-out;
 }
 
-.book--completed {
+.book:hover,
+.book:focus-visible {
+  border-color: var(--mat-sys-primary);
+  outline: none;
+}
+
+.book:active {
+  transform: scale(0.997);
+}
+
+.book[aria-disabled='true'] {
+  cursor: progress;
   opacity: 0.7;
+  pointer-events: none;
 }
 
 .book-header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 12px;
-}
-
-.book-meta {
   display: grid;
   gap: 2px;
 }
 
 .book-title {
-  color: var(--mat-sys-on-primary);
-  font-size: 16px;
-  font-weight: 600;
   margin: 0;
+  color: var(--mat-sys-on-primary);
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
 .book-author {
-  color: var(--mat-app-text-color);
-  font-size: 13px;
   margin: 0;
+  color: var(--mat-app-text-color);
+  font-size: 12px;
 }
 
 .book-progress-bar {
@@ -139,49 +89,48 @@ h2 {
   transition: width 250ms ease-out;
 }
 
-.book-progress {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  flex-wrap: wrap;
-}
-
-.page-input {
-  flex: 1 1 160px;
-}
-
-.book-stats {
-  color: var(--mat-app-text-color);
-  font-size: 13px;
-  margin: 0;
-  display: flex;
-  gap: 6px;
-  flex-wrap: wrap;
-}
-
-.add-book {
+.stats {
   display: grid;
+  grid-template-columns: repeat(3, 1fr);
   gap: 12px;
-  padding: 16px;
-  border-radius: 0.75rem;
-  background: var(--mat-sys-surface-container);
-}
-
-.add-book h3 {
-  color: var(--mat-sys-on-primary);
-  font-size: 16px;
-  font-weight: 600;
   margin: 0;
 }
 
-.actions {
-  display: flex;
-  gap: 8px;
-  justify-content: flex-end;
+.stat {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
 }
 
-.add-button {
-  justify-self: stretch;
+dt {
+  color: var(--mat-app-text-color);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+}
+
+dd {
+  margin: 0;
+  display: flex;
+  align-items: baseline;
+  gap: 4px;
+  min-width: 0;
+}
+
+.stat-value {
+  color: var(--mat-sys-on-primary);
+  font-size: 26px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+
+.stat-unit {
+  color: var(--mat-app-text-color);
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .page-loading {

--- a/client/src/app/reading/reading.component.html
+++ b/client/src/app/reading/reading.component.html
@@ -1,52 +1,28 @@
-@if (books.isLoading() || stats.isLoading()) {
+@if (books.isLoading()) {
 <mat-spinner class="page-loading" />
 } @else {
 <section class="reading" aria-labelledby="reading-heading">
   <header class="header">
     <h2 id="reading-heading">Reading</h2>
-    @if (dailyGoal() > 0) {
-    <p class="subtitle">
-      @if (goalReached()) { Daily goal reached } @else {
-      {{ remaining() }} pages to go
-      }
-    </p>
-    }
   </header>
-
-  @if (dailyGoal() > 0) {
-  <div
-    class="ring-wrapper"
-    role="img"
-    [attr.aria-label]="todayPages() + ' of ' + dailyGoal() + ' pages today'"
-  >
-    <svg class="ring" viewBox="0 0 120 120" aria-hidden="true">
-      <circle class="ring-track" cx="60" cy="60" r="52" />
-      <circle
-        class="ring-progress"
-        [class.ring-progress--complete]="goalReached()"
-        cx="60"
-        cy="60"
-        r="52"
-        [style.stroke-dashoffset.px]="326.7 - (326.7 * progressPercent()) / 100"
-      />
-    </svg>
-    <div class="ring-content">
-      <span class="ring-count">{{ todayPages() }}</span>
-      <span class="ring-goal">/ {{ dailyGoal() }}</span>
-    </div>
-  </div>
-  }
 
   <div class="books">
     @if (inProgressBooks().length === 0) {
     <p class="empty">No books in progress. Add a book in Settings.</p>
     } @for (book of inProgressBooks(); track book.id) {
-    <article class="book" [attr.aria-label]="ariaForBook(book)">
+    <div
+      class="book"
+      role="button"
+      [attr.tabindex]="busy() ? -1 : 0"
+      [attr.aria-label]="ariaForBook(book)"
+      [attr.aria-disabled]="busy()"
+      (click)="openProgressDialog(book)"
+      (keydown.enter)="openProgressDialog(book); $event.preventDefault()"
+      (keydown.space)="openProgressDialog(book); $event.preventDefault()"
+    >
       <header class="book-header">
-        <div class="book-meta">
-          <h3 class="book-title">{{ book.title }}</h3>
-          <p class="book-author">{{ book.author }}</p>
-        </div>
+        <h3 class="book-title">{{ book.title }}</h3>
+        <p class="book-author">{{ book.author }}</p>
       </header>
 
       <div class="book-progress-bar" aria-hidden="true">
@@ -56,39 +32,30 @@
         ></div>
       </div>
 
-      <div class="book-progress">
-        <mat-form-field appearance="outline" class="page-input">
-          <mat-label>Current page</mat-label>
-          <input
-            matInput
-            type="number"
-            [min]="book.startingPage"
-            [max]="book.totalPages"
-            [value]="pageInputValue(book)"
-            (input)="setPageInput(book, +$any($event.target).value)"
-            [attr.aria-label]="'Current page for ' + book.title"
-          />
-          <span matTextSuffix>/ {{ book.totalPages }}</span>
-        </mat-form-field>
-        <button
-          mat-flat-button
-          color="primary"
-          type="button"
-          [disabled]="busy() || pageInputValue(book) === book.currentPage"
-          (click)="saveProgress(book)"
-        >
-          Save
-        </button>
-      </div>
-
-      <p class="book-stats">
-        @if (estimatedFinishLabel(book); as label) {
-        <span>{{ label }}</span>
-        } @if (averageLabel(book); as label) {
-        <span>· {{ label }}</span>
-        }
-      </p>
-    </article>
+      <dl class="stats">
+        <div class="stat">
+          <dt>Page</dt>
+          <dd>
+            <span class="stat-value">{{ book.currentPage }}</span>
+            <span class="stat-unit">of {{ book.totalPages }}</span>
+          </dd>
+        </div>
+        <div class="stat">
+          <dt>Pace</dt>
+          <dd>
+            <span class="stat-value">{{ averageLabel(book) }}</span>
+            <span class="stat-unit">pages/day</span>
+          </dd>
+        </div>
+        <div class="stat">
+          <dt>Remaining</dt>
+          <dd>
+            <span class="stat-value">{{ daysLabel(book) }}</span>
+            <span class="stat-unit">{{ daysUnit(book) }}</span>
+          </dd>
+        </div>
+      </dl>
+    </div>
     }
   </div>
 </section>

--- a/client/src/app/reading/reading.component.ts
+++ b/client/src/app/reading/reading.component.ts
@@ -1,79 +1,34 @@
 import { Component, computed, inject, resource, signal } from '@angular/core';
-import { FormsModule } from '@angular/forms';
-import { MatButtonModule } from '@angular/material/button';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
+import { MatDialog } from '@angular/material/dialog';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import {
+  ReadingProgressDialogComponent,
+  ReadingProgressDialogData,
+  ReadingProgressDialogResult,
+} from './reading-progress-dialog.component';
 import { Book, ReadingService } from './reading.service';
 
 @Component({
   standalone: true,
-  imports: [
-    FormsModule,
-    MatButtonModule,
-    MatFormFieldModule,
-    MatInputModule,
-    MatProgressSpinnerModule,
-  ],
+  imports: [MatProgressSpinnerModule],
   selector: 'app-reading',
   templateUrl: './reading.component.html',
   styleUrl: './reading.component.css',
 })
 export class ReadingComponent {
   private readonly readingService = inject(ReadingService);
+  private readonly dialog = inject(MatDialog);
 
   readonly busy = signal(false);
-  readonly progressInputs = signal<Record<string, number>>({});
 
   readonly books = resource({
     params: () => this.readingService.version(),
     loader: () => this.readingService.getBooks(),
   });
 
-  readonly stats = resource({
-    params: () => this.readingService.version(),
-    loader: () => this.readingService.getStats(),
-  });
-
-  readonly dailyGoal = computed(() => this.stats.value()?.dailyPagesGoal ?? 0);
-  readonly todayPages = computed(() => this.stats.value()?.todayPages ?? 0);
-  readonly remaining = computed(() => Math.max(0, this.dailyGoal() - this.todayPages()));
-  readonly goalReached = computed(
-    () => this.dailyGoal() > 0 && this.todayPages() >= this.dailyGoal()
-  );
-  readonly progressPercent = computed(() => {
-    const goal = this.dailyGoal();
-    return goal > 0 ? Math.min(100, (this.todayPages() / goal) * 100) : 0;
-  });
-
   readonly inProgressBooks = computed(
     () => this.books.value()?.filter((book) => !book.completedAt) ?? []
   );
-
-  pageInputValue(book: Book): number {
-    return this.progressInputs()[book.id] ?? book.currentPage;
-  }
-
-  setPageInput(book: Book, value: number) {
-    this.progressInputs.update((map) => ({ ...map, [book.id]: value }));
-  }
-
-  async saveProgress(book: Book) {
-    const value = this.pageInputValue(book);
-    if (this.busy() || value === book.currentPage) return;
-    if (value < book.startingPage || value > book.totalPages) return;
-    this.busy.set(true);
-    try {
-      await this.readingService.updateProgress(book.id, value);
-      this.progressInputs.update((map) => {
-        const next = { ...map };
-        delete next[book.id];
-        return next;
-      });
-    } finally {
-      this.busy.set(false);
-    }
-  }
 
   bookProgressPercent(book: Book): number {
     return book.totalPages > 0
@@ -85,23 +40,53 @@ export class ReadingComponent {
     return `${book.title}, ${book.currentPage} of ${book.totalPages} pages`;
   }
 
-  estimatedFinishLabel(book: Book): string | null {
+  daysLabel(book: Book): string {
     if (book.estimatedDaysRemaining === undefined || book.estimatedDaysRemaining === null) {
-      return null;
+      return '–';
     }
-    if (book.estimatedDaysRemaining === 0) {
-      return 'Ready to finish';
-    }
-    if (book.estimatedDaysRemaining === 1) {
-      return 'About 1 day to finish';
-    }
-    return `About ${book.estimatedDaysRemaining} days to finish`;
+    return String(book.estimatedDaysRemaining);
   }
 
-  averageLabel(book: Book): string | null {
-    if (book.averagePagesPerDay === undefined || book.averagePagesPerDay === null) {
-      return null;
+  daysUnit(book: Book): string {
+    if (book.estimatedDaysRemaining === 1) {
+      return 'day left';
     }
-    return `${book.averagePagesPerDay.toFixed(1)} pages/day avg`;
+    return 'days left';
+  }
+
+  averageLabel(book: Book): string {
+    if (book.averagePagesPerDay === undefined || book.averagePagesPerDay === null) {
+      return '–';
+    }
+    return book.averagePagesPerDay.toFixed(1);
+  }
+
+  openProgressDialog(book: Book): void {
+    if (this.busy()) {
+      return;
+    }
+    const ref = this.dialog.open<
+      ReadingProgressDialogComponent,
+      ReadingProgressDialogData,
+      ReadingProgressDialogResult
+    >(ReadingProgressDialogComponent, {
+      data: { book },
+      autoFocus: 'dialog',
+      restoreFocus: true,
+    });
+    ref.afterClosed().subscribe((page) => {
+      if (typeof page === 'number' && page !== book.currentPage) {
+        this.updateProgress(book, page);
+      }
+    });
+  }
+
+  private async updateProgress(book: Book, page: number) {
+    this.busy.set(true);
+    try {
+      await this.readingService.updateProgress(book.id, page);
+    } finally {
+      this.busy.set(false);
+    }
   }
 }

--- a/client/src/app/reading/reading.service.ts
+++ b/client/src/app/reading/reading.service.ts
@@ -31,12 +31,6 @@ type BookDto = {
   estimatedDaysRemaining?: number;
 };
 
-export type ReadingStats = {
-  todayPages: number;
-  dailyPagesGoal: number;
-  goalReached: boolean;
-};
-
 const toBook = (dto: BookDto): Book => ({
   ...dto,
   createdAt: new Date(dto.createdAt),
@@ -56,15 +50,6 @@ export class ReadingService {
       return books.map(toBook);
     } catch (e) {
       this.showError('Unable to fetch books');
-      throw e;
-    }
-  }
-
-  async getStats(): Promise<ReadingStats> {
-    try {
-      return await fetchJson<ReadingStats>(this.http, '/api/reading/stats');
-    } catch (e) {
-      this.showError('Unable to fetch reading stats');
       throw e;
     }
   }

--- a/test/tests/reading.spec.ts
+++ b/test/tests/reading.spec.ts
@@ -37,20 +37,12 @@ test.describe('Reading', () => {
     await expect(
       section.getByText('No books in progress. Add a book in Settings.')
     ).toBeVisible();
-    await expect(section.getByRole('img', { name: '0 of 30 pages today' })).toBeVisible();
 
     await page.goto('/settings');
     const library = page.getByRole('region', { name: 'Books' });
     await expect(
       library.getByText('No books yet. Add your first one to get started.')
     ).toBeVisible();
-  });
-
-  test('hides daily goal ring when reading goal is 0', async ({ page }) => {
-    await page.goto('/');
-    const section = page.getByRole('region', { name: 'Reading' });
-    await expect(section).toBeVisible();
-    await expect(section.getByRole('img', { name: /pages today/ })).toBeHidden();
   });
 
   test('adds a new book through the settings page', async ({ page }) => {
@@ -105,7 +97,7 @@ test.describe('Reading', () => {
     await page.goto('/');
     const section = page.getByRole('region', { name: 'Reading' });
     await expect(
-      section.getByRole('article', { name: /Already Started, 80 of 300 pages/ })
+      section.getByRole('button', { name: /Already Started, 80 of 300 pages/ })
     ).toBeVisible();
   });
 
@@ -127,11 +119,13 @@ test.describe('Reading', () => {
 
     await page.goto('/');
     const section = page.getByRole('region', { name: 'Reading' });
-    await expect(
-      section.getByRole('article', { name: /Resumed Book, 140 of 300 pages/ })
-    ).toBeVisible();
-    await expect(section.getByText('8.0 pages/day avg')).toBeVisible();
-    await expect(section.getByText('About 20 days to finish')).toBeVisible();
+    const book = section.getByRole('button', {
+      name: /Resumed Book, 140 of 300 pages/,
+    });
+    await expect(book).toBeVisible();
+    await expect(book.getByText('8.0', { exact: true })).toBeVisible();
+    await expect(book.getByText('20', { exact: true })).toBeVisible();
+    await expect(book.getByText('days left')).toBeVisible();
   });
 
   test('only counts pages read past the starting page toward the daily goal', async ({
@@ -151,10 +145,8 @@ test.describe('Reading', () => {
     await insertReadingProgress(bookId, 115, daysAgoAt(0, 12));
 
     await page.goto('/');
-    const section = page.getByRole('region', { name: 'Reading' });
-    await expect(
-      section.getByRole('img', { name: '15 of 30 pages today' })
-    ).toBeVisible();
+    const golden = page.getByRole('region', { name: 'Golden day' });
+    await expect(golden.getByText('15/30 pages')).toBeVisible();
   });
 
   test('does not expose book add or remove controls on the dashboard', async ({
@@ -179,17 +171,27 @@ test.describe('Reading', () => {
 
     await page.goto('/');
     const section = page.getByRole('region', { name: 'Reading' });
-    const input = section.getByLabel('Current page for Clean Code');
-    await input.fill('120');
-    await section.getByRole('button', { name: 'Save' }).click();
+    await section.getByRole('button', { name: /Clean Code/ }).click();
+
+    const dialog = page.getByRole('dialog', { name: 'Clean Code' });
+    const dial = dialog.getByRole('spinbutton', {
+      name: 'Current page for Clean Code',
+    });
+    await dial.focus();
+    for (let i = 0; i < 5; i++) {
+      await page.keyboard.press('PageUp');
+    }
+    await expect(dial).toHaveAttribute('aria-valuenow', '125');
+    await dialog.getByRole('button', { name: 'Save 125' }).click();
+    await expect(dialog).toBeHidden();
 
     await expect(
-      section.getByRole('article', { name: /Clean Code, 120 of 400 pages/ })
+      section.getByRole('button', { name: /Clean Code, 125 of 400 pages/ })
     ).toBeVisible();
 
     const progress = await getReadingProgressRows();
     expect(progress).toHaveLength(1);
-    expect(progress[0].current_page).toBe(120);
+    expect(progress[0].current_page).toBe(125);
   });
 
   test('aggregates pages read across books toward the daily goal', async ({ page }) => {
@@ -204,9 +206,8 @@ test.describe('Reading', () => {
     await insertReadingProgress(bookB, 8, daysAgoAt(0, 12));
 
     await page.goto('/');
-    const section = page.getByRole('region', { name: 'Reading' });
-    await expect(section.getByRole('img', { name: '20 of 30 pages today' })).toBeVisible();
-    await expect(section.getByText('10 pages to go')).toBeVisible();
+    const golden = page.getByRole('region', { name: 'Golden day' });
+    await expect(golden.getByText('20/30 pages')).toBeVisible();
   });
 
   test('shows daily goal reached when total pages match the goal', async ({ page }) => {
@@ -217,9 +218,8 @@ test.describe('Reading', () => {
     await insertReadingProgress(bookId, 30, daysAgoAt(0, 12));
 
     await page.goto('/');
-    const section = page.getByRole('region', { name: 'Reading' });
-    await expect(section.getByRole('img', { name: '30 of 30 pages today' })).toBeVisible();
-    await expect(section.getByText('Daily goal reached')).toBeVisible();
+    const golden = page.getByRole('region', { name: 'Golden day' });
+    await expect(golden.getByText('30/30 pages')).toBeVisible();
   });
 
   test('shows estimated days to finish based on reading velocity', async ({ page }) => {
@@ -230,8 +230,9 @@ test.describe('Reading', () => {
 
     await page.goto('/');
     const section = page.getByRole('region', { name: 'Reading' });
-    await expect(section.getByText(/About \d+ days? to finish/)).toBeVisible();
-    await expect(section.getByText(/pages\/day avg/)).toBeVisible();
+    const book = section.getByRole('button', { name: /Long Book/ });
+    await expect(book.getByText(/days? left/)).toBeVisible();
+    await expect(book.getByText('pages/day')).toBeVisible();
   });
 
   test('marks a book as finished when current page reaches total pages', async ({ page }) => {
@@ -240,8 +241,19 @@ test.describe('Reading', () => {
 
     await page.goto('/');
     const section = page.getByRole('region', { name: 'Reading' });
-    await section.getByLabel('Current page for Almost Done').fill('100');
-    await section.getByRole('button', { name: 'Save' }).click();
+    await section.getByRole('button', { name: /Almost Done/ }).click();
+
+    const dialog = page.getByRole('dialog', { name: 'Almost Done' });
+    const dial = dialog.getByRole('spinbutton', {
+      name: 'Current page for Almost Done',
+    });
+    await dial.focus();
+    for (let i = 0; i < 4; i++) {
+      await page.keyboard.press('PageUp');
+    }
+    await expect(dial).toHaveAttribute('aria-valuenow', '100');
+    await dialog.getByRole('button', { name: 'Save 100' }).click();
+    await expect(dialog).toBeHidden();
 
     await expect(
       section.getByRole('heading', { name: 'Almost Done' })
@@ -316,8 +328,7 @@ test.describe('Reading', () => {
     await insertReadingProgress(bookId, 20, daysAgoAt(0, 12));
 
     await page.goto('/');
-    const section = page.getByRole('region', { name: 'Reading' });
-    await expect(section.getByRole('img', { name: '20 of 50 pages today' })).toBeVisible();
-    await expect(section.getByText('30 pages to go')).toBeVisible();
+    const golden = page.getByRole('region', { name: 'Golden day' });
+    await expect(golden.getByText('20/50 pages')).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary
Redesigned the reading progress interface to use a dialog-based interaction model instead of inline form fields. The daily reading goal ring has been removed, and book cards now function as clickable buttons that open a dialog for updating progress.

## Key Changes
- **Reading Progress Dialog**: Created new `ReadingProgressDialogComponent` with a circular slider for intuitive page input, replacing inline number inputs
- **Book Card Redesign**: Converted book cards from articles to interactive buttons with hover/focus states and click handlers
- **Removed Daily Goal Ring**: Eliminated the SVG progress ring and daily goal tracking UI from the reading component
- **Stats Display Refactoring**: Replaced inline stats text with a structured 3-column grid layout showing page, pace, and remaining days
- **Circular Slider Enhancement**: Extended `CircularSliderComponent` with configurable min/max bounds, unit labels, and improved accessibility attributes
- **Removed Stats API**: Eliminated `getStats()` method and `ReadingStats` type from reading service
- **Simplified Component Logic**: Removed progress input state management and inline save handlers in favor of dialog-based workflow

## Implementation Details
- Book cards now use semantic button role with proper keyboard support (Enter/Space keys)
- Dialog uses Material Dialog with auto-focus and restore-focus behavior
- Stats display uses definition list (`<dl>`) semantics with styled values and units
- Circular slider now properly supports custom min/max ranges and unit labels for better reusability
- Updated test suite to reflect new button-based interaction model and dialog workflow

https://claude.ai/code/session_017xi98kPr7rPrxb1hCmduV1