### PR TITLE
Add data labels and hint text to pushups chart

### DIFF
--- a/client/src/app/pushups/pushups.component.css
+++ b/client/src/app/pushups/pushups.component.css
@@ -44,6 +44,16 @@ h2 {
   inset: 0;
 }
 
+.hint {
+  position: absolute;
+  top: 4px;
+  right: 8px;
+  font-size: 11px;
+  color: var(--mat-sys-on-surface-variant);
+  opacity: 0.7;
+  pointer-events: none;
+}
+
 .page-loading {
   margin: 150px auto;
 }

--- a/client/src/app/pushups/pushups.component.html
+++ b/client/src/app/pushups/pushups.component.html
@@ -22,6 +22,7 @@
       [options]="chart"
       [initOpts]="initOpts"
     ></div>
+    <span class="hint" aria-hidden="true">Click to add</span>
   </button>
   }
 </section>

--- a/client/src/app/pushups/pushups.component.ts
+++ b/client/src/app/pushups/pushups.component.ts
@@ -103,8 +103,8 @@ export class PushupsComponent {
             color: 'hsl(0, 0%, 100%)',
             fontSize: 11,
             fontWeight: 600,
-            formatter: (params: { value: [Date, number | null] }) => {
-              const value = params.value[1];
+            formatter: (params) => {
+              const value = (params.value as [Date, number | null])[1];
               return value ? String(value) : '';
             },
           },

--- a/client/src/app/pushups/pushups.component.ts
+++ b/client/src/app/pushups/pushups.component.ts
@@ -83,7 +83,7 @@ export class PushupsComponent {
     return {
       aria: { enabled: true },
       animation: false,
-      grid: { top: 10, right: 10, bottom: 10, left: 10 },
+      grid: { top: 24, right: 10, bottom: 10, left: 10 },
       xAxis: {
         type: 'time',
         show: false,
@@ -97,6 +97,17 @@ export class PushupsComponent {
           type: 'bar',
           data,
           itemStyle: { color: 'hsl(220, 89%, 53%)' },
+          label: {
+            show: true,
+            position: 'top',
+            color: 'hsl(0, 0%, 100%)',
+            fontSize: 11,
+            fontWeight: 600,
+            formatter: (params: { value: [Date, number | null] }) => {
+              const value = params.value[1];
+              return value ? String(value) : '';
+            },
+          },
           markLine: {
             silent: true,
             symbol: 'none',


### PR DESCRIPTION
## Summary
Enhanced the pushups chart visualization by adding data labels above each bar and a hint text to guide users on how to interact with the chart.

## Key Changes
- **Chart labels**: Added data labels displaying the pushup count above each bar with white text, 11px font size, and bold weight
- **Grid spacing**: Increased top grid padding from 10 to 24 to accommodate the new labels
- **Hint text**: Added "Click to add" hint text in the top-right corner of the chart container with reduced opacity for subtle guidance
- **Label formatting**: Implemented a formatter function that displays numeric values and handles null values gracefully

## Implementation Details
- Labels are positioned at the top of each bar using ECharts' label configuration
- The hint text uses absolute positioning and is marked with `aria-hidden="true"` since it's purely decorative
- Label color uses the same blue as the bars (`hsl(220, 89%, 53%)`) but inverted to white for contrast
- The hint text color uses the Material Design system color `--mat-sys-on-surface-variant` with 0.7 opacity for visual hierarchy

https://claude.ai/code/session_01WBuBP4b7HVp8wvVke4QjZw