### PR TITLE
Remove hint text from pushups chart

### DIFF
--- a/client/src/app/pushups/pushups.component.css
+++ b/client/src/app/pushups/pushups.component.css
@@ -44,16 +44,6 @@ h2 {
   inset: 0;
 }
 
-.hint {
-  position: absolute;
-  top: 4px;
-  right: 8px;
-  font-size: 11px;
-  color: var(--mat-sys-on-surface-variant);
-  opacity: 0.7;
-  pointer-events: none;
-}
-
 .page-loading {
   margin: 150px auto;
 }

--- a/client/src/app/pushups/pushups.component.html
+++ b/client/src/app/pushups/pushups.component.html
@@ -22,7 +22,6 @@
       [options]="chart"
       [initOpts]="initOpts"
     ></div>
-    <span class="hint" aria-hidden="true">Click to add</span>
   </button>
   }
 </section>


### PR DESCRIPTION
## Summary
Removed the "Click to add" hint text and its associated styling from the pushups chart component.

## Changes
- Removed the `.hint` CSS class definition from `pushups.component.css` (11 lines)
- Removed the `<span class="hint">` element from `pushups.component.html`

## Details
The hint span was marked with `aria-hidden="true"`, indicating it was a visual-only affordance. This change simplifies the UI by removing this supplementary guidance text and its styling rules.

https://claude.ai/code/session_01BHt1yoMzF5FN49upnbnYA7