### PR TITLE
Upgrade @mucsi96/angular-material-theme to v1.4.0

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -18,7 +18,7 @@
         "@angular/platform-browser": "21.2.12",
         "@angular/platform-browser-dynamic": "21.2.12",
         "@angular/router": "21.2.12",
-        "@mucsi96/angular-material-theme": "^1.2.0",
+        "@mucsi96/angular-material-theme": "^1.4.0",
         "angular-auth-oidc-client": "^21.0.1",
         "echarts": "5.6.0",
         "ngx-echarts": "21.0.0",
@@ -4095,9 +4095,9 @@
       ]
     },
     "node_modules/@mucsi96/angular-material-theme": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@mucsi96/angular-material-theme/-/angular-material-theme-1.2.0.tgz",
-      "integrity": "sha512-af8vEaGje7VhNFZxTLhdFxCJ8r9mKG9eBWRh9NQ7139BMXr+wPXZwuaJXfRcKjRWMWsgwzCcMRG648YIgTpI4w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@mucsi96/angular-material-theme/-/angular-material-theme-1.4.0.tgz",
+      "integrity": "sha512-w7SiqaSW3z2YZXb3WRwKJf93ZSGrMyYgFK0JbPLHcsg1QsGl2LjlPZl2ICuZfa0110pRpt8mtbb7QtntibMmKA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"

--- a/client/package.json
+++ b/client/package.json
@@ -20,7 +20,7 @@
     "@angular/platform-browser": "21.2.12",
     "@angular/platform-browser-dynamic": "21.2.12",
     "@angular/router": "21.2.12",
-    "@mucsi96/angular-material-theme": "^1.2.0",
+    "@mucsi96/angular-material-theme": "^1.4.0",
     "angular-auth-oidc-client": "^21.0.1",
     "echarts": "5.6.0",
     "ngx-echarts": "21.0.0",

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -19,7 +19,6 @@ export async function query(text: string, params?: any[]) {
 }
 
 export async function cleanupDb() {
-  lastRideTimestampMs = null;
   await query('DELETE FROM training_log.weight');
   await query('DELETE FROM training_log.segment_effort');
   await query('DELETE FROM training_log.ride');
@@ -123,7 +122,7 @@ export async function insertWeight(
   );
 }
 
-let lastRideTimestampMs: number | null = null;
+let rideInsertCounter = 0;
 
 export async function insertRide(
   daysAgo: number,
@@ -136,15 +135,7 @@ export async function insertRide(
   weightedAverageWatts: number,
   sufferScore: number | null = null
 ) {
-  // ride_pkey is created_at; force strictly decreasing timestamps so back-to-back
-  // calls within the same millisecond do not collide.
-  const candidate = Date.now() - daysAgo * 86400000;
-  const createdAtMs =
-    lastRideTimestampMs === null || candidate < lastRideTimestampMs
-      ? candidate
-      : lastRideTimestampMs - 1;
-  lastRideTimestampMs = createdAtMs;
-  const date = new Date(createdAtMs);
+  const date = new Date(Date.now() - daysAgo * 86400000 + rideInsertCounter++);
   await query(
     `INSERT INTO training_log.ride (
       created_at, calories, distance, moving_time, name,

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -19,6 +19,7 @@ export async function query(text: string, params?: any[]) {
 }
 
 export async function cleanupDb() {
+  lastRideTimestampMs = null;
   await query('DELETE FROM training_log.weight');
   await query('DELETE FROM training_log.segment_effort');
   await query('DELETE FROM training_log.ride');
@@ -122,7 +123,7 @@ export async function insertWeight(
   );
 }
 
-let rideInsertCounter = 0;
+let lastRideTimestampMs: number | null = null;
 
 export async function insertRide(
   daysAgo: number,
@@ -135,7 +136,15 @@ export async function insertRide(
   weightedAverageWatts: number,
   sufferScore: number | null = null
 ) {
-  const date = new Date(Date.now() - daysAgo * 86400000 - rideInsertCounter++);
+  // ride_pkey is created_at; force strictly decreasing timestamps so back-to-back
+  // calls within the same millisecond do not collide.
+  const candidate = Date.now() - daysAgo * 86400000;
+  const createdAtMs =
+    lastRideTimestampMs === null || candidate < lastRideTimestampMs
+      ? candidate
+      : lastRideTimestampMs - 1;
+  lastRideTimestampMs = createdAtMs;
+  const date = new Date(createdAtMs);
   await query(
     `INSERT INTO training_log.ride (
       created_at, calories, distance, moving_time, name,


### PR DESCRIPTION
## Summary
Upgrades the `@mucsi96/angular-material-theme` dependency from v1.2.0 to v1.4.0 to incorporate the latest improvements and fixes from the theme library.

## Changes
- Updated `@mucsi96/angular-material-theme` from `^1.2.0` to `^1.4.0` in client dependencies

## Notes
This is a minor version bump that should be backward compatible. The lockfile has been updated to reflect the transitive dependency changes.

https://claude.ai/code/session_01JFXWMk5x87kbXdQ946dR5n