### PR TITLE
Refactor colors to use CSS custom properties

### DIFF
--- a/client/src/app/app.component.css
+++ b/client/src/app/app.component.css
@@ -1,5 +1,5 @@
 .header {
-  border-bottom: 1px solid hsl(215, 14%, 34%);
+  border-bottom: 1px solid var(--bt-outline);
   display: block;
   padding: env(safe-area-inset-top) 0 0;
 
@@ -11,6 +11,10 @@
     align-items: center;
     gap: 1rem;
     height: 100%;
+
+    a[mat-button] {
+      font-size: 16px;
+    }
   }
 }
 

--- a/client/src/app/header/header.component.css
+++ b/client/src/app/header/header.component.css
@@ -7,13 +7,13 @@
 .avatar {
   display: inline-flex;
   user-select: none;
-  background-color: hsl(215, 14%, 34%);
+  background-color: var(--bt-outline);
   border-radius: 50%;
   height: 40px;
   justify-content: center;
   align-items: center;
   aspect-ratio: 1;
-  color: white;
+  color: var(--bt-text-on-brand);
   font-size: 18px;
   border: unset;
 }
@@ -29,5 +29,5 @@
   padding-left: var(--mat-menu-item-leading-spacing);
   padding-right: var(--mat-menu-item-trailing-spacing);
   min-height: 36px;
-  color: var(--mat-sys-on-surface);
+  color: var(--bt-text-default);
 }


### PR DESCRIPTION
## Summary
Replaced hardcoded color values with CSS custom properties to improve maintainability and enable consistent theming across the application.

## Key Changes
- Replaced hardcoded `hsl(215, 14%, 34%)` with `var(--bt-outline)` in app and header components
- Replaced hardcoded `white` with `var(--bt-text-on-brand)` for avatar text color
- Replaced `var(--mat-sys-on-surface)` with `var(--bt-text-default)` for menu item text color
- Added font-size styling (16px) for mat-button elements in the header navigation

## Implementation Details
These changes centralize color definitions through CSS custom properties, making it easier to maintain a consistent design system and support theme variations. The custom properties (`--bt-outline`, `--bt-text-on-brand`, `--bt-text-default`) should be defined in a global stylesheet or theme configuration.

https://claude.ai/code/session_01SoSbNgSzMCT4hMKDVavjJs