### PR TITLE
Make Withings fat measurements optional

### DIFF
--- a/mock_withings_server/src/index.ts
+++ b/mock_withings_server/src/index.ts
@@ -1,11 +1,12 @@
 import express from 'express';
 import { authorize } from './authorize';
 import { getAccessToken } from './getAccessToken';
-import { measure } from './measure';
+import { measure, resetMeasureScenario, setMeasureScenario } from './measure';
 
 const app = express();
 
 app.use(express.urlencoded({ extended: true }));
+app.use(express.json());
 
 app.use((req, res, next) => {
   if (req.path !== '/health') {
@@ -18,6 +19,8 @@ app.use((req, res, next) => {
 app.get('/withings/oauth2_user/authorize2', authorize);
 app.post('/withings/v2/oauth2', getAccessToken);
 app.post('/withings/measure', measure);
+app.post('/withings/test/measure', setMeasureScenario);
+app.post('/withings/test/reset', resetMeasureScenario);
 
 app.get('/health', (req, res) => {
   res.json({ status: 'ok' });

--- a/mock_withings_server/src/measure.ts
+++ b/mock_withings_server/src/measure.ts
@@ -1,5 +1,37 @@
 import { Request, Response } from 'express';
 
+type Measure = {
+  value: number;
+  type: number;
+  unit: number;
+  algo?: number;
+  fm?: number;
+  fw?: number;
+};
+
+const DEFAULT_MEASURES: Measure[] = [
+  { value: 871532, type: 1, unit: -4, algo: 3425, fm: 1, fw: 1000 },
+  { value: 352664, type: 6, unit: -4, algo: 3425, fm: 1, fw: 1000 },
+  { value: 217634, type: 8, unit: -4, algo: 3425, fm: 1, fw: 1000 },
+];
+
+let nextMeasures: Measure[] = DEFAULT_MEASURES;
+
+export function resetMeasureScenario(_req: Request, res: Response) {
+  nextMeasures = DEFAULT_MEASURES;
+  res.json({ status: 'ok' });
+}
+
+export function setMeasureScenario(req: Request, res: Response) {
+  const body = req.body as { measures?: Measure[] } | undefined;
+  if (!body || !Array.isArray(body.measures)) {
+    res.status(400).json({ error: 'measures array required' });
+    return;
+  }
+  nextMeasures = body.measures;
+  res.json({ status: 'ok' });
+}
+
 export function measure(req: Request, res: Response) {
   const authorization = req.headers.authorization;
   const action = req.query.action as string | undefined;
@@ -64,32 +96,7 @@ export function measure(req: Request, res: Response) {
           modified: date.getTime() / 1000,
           category: 1594257200,
           deviceid: '892359876fd8805ac45bab078c4828692f0276b1',
-          measures: [
-            {
-              value: 871532,
-              type: 1,
-              unit: -4,
-              algo: 3425,
-              fm: 1,
-              fw: 1000,
-            },
-            {
-              value: 352664,
-              type: 6,
-              unit: -4,
-              algo: 3425,
-              fm: 1,
-              fw: 1000,
-            },
-            {
-              value: 217634,
-              type: 8,
-              unit: -4,
-              algo: 3425,
-              fm: 1,
-              fw: 1000,
-            },
-          ],
+          measures: nextMeasures,
           comment: 'A measurement comment',
           timezone: 'Europe/Paris',
         },
@@ -99,6 +106,6 @@ export function measure(req: Request, res: Response) {
     },
   };
 
-  console.log('[measure] Response: measuregrps with', response.body.measuregrps.length, 'groups');
+  console.log('[measure] Response: measuregrps with', response.body.measuregrps.length, 'groups,', nextMeasures.length, 'measures');
   res.json(response);
 }

--- a/server/src/main/java/mucsi96/traininglog/weight/Weight.java
+++ b/server/src/main/java/mucsi96/traininglog/weight/Weight.java
@@ -25,8 +25,8 @@ public class Weight {
     private float weight;
 
     @Column
-    private float fatMassWeight;
+    private Float fatMassWeight;
 
     @Column
-    private float fatRatio;
+    private Float fatRatio;
 }

--- a/server/src/main/java/mucsi96/traininglog/withings/WithingsService.java
+++ b/server/src/main/java/mucsi96/traininglog/withings/WithingsService.java
@@ -119,13 +119,19 @@ public class WithingsService {
       return Optional.empty();
     }
 
+    Optional<Float> weight = getMeasurement(measures, MEASURE_TYPE_WEIGHT);
+    if (weight.isEmpty()) {
+      log.info("Withings measure group {} has no weight measurement, skipping", measureGroup.getGrpid());
+      return Optional.empty();
+    }
+
     return Optional.of(
         Weight
             .builder()
             .createdAt(ZonedDateTime.ofInstant(Instant.ofEpochSecond(measureGroup.getDate()), ZoneOffset.UTC))
-            .weight(getMeasurement(measures, MEASURE_TYPE_WEIGHT).orElseThrow())
-            .fatRatio(getMeasurement(measures, MEASURE_TYPE_FAT_RATIO).orElseThrow())
-            .fatMassWeight(getMeasurement(measures, MEASURE_TYPE_FAT_MASS_WEIGHT).orElseThrow())
+            .weight(weight.get())
+            .fatRatio(getMeasurement(measures, MEASURE_TYPE_FAT_RATIO).orElse(null))
+            .fatMassWeight(getMeasurement(measures, MEASURE_TYPE_FAT_MASS_WEIGHT).orElse(null))
             .build());
   }
 

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -1,5 +1,5 @@
 import { test as base, expect } from '@playwright/test';
-import { cleanupDb, populateOAuthClients, resetStravaActivities } from './utils';
+import { cleanupDb, populateOAuthClients, resetStravaActivities, resetWithingsMeasures } from './utils';
 
 type ConsoleEntry = {
   timestamp: string;
@@ -14,6 +14,7 @@ export const test = base.extend<{ forEachTest: void }>({
       await cleanupDb();
       await populateOAuthClients();
       await resetStravaActivities();
+      await resetWithingsMeasures();
 
       const consoleLogs: ConsoleEntry[] = [];
 

--- a/test/tests/withings.spec.ts
+++ b/test/tests/withings.spec.ts
@@ -1,5 +1,12 @@
 import { test, expect } from '../fixtures';
-import { cleanupDb, populateOAuthClients, deleteOAuthClient, getOAuthClient } from '../utils';
+import {
+  cleanupDb,
+  populateOAuthClients,
+  deleteOAuthClient,
+  getOAuthClient,
+  setWithingsMeasures,
+  getWeightRows,
+} from '../utils';
 
 test.describe('Withings', () => {
   test('should authorize withings', async ({ page }) => {
@@ -25,5 +32,36 @@ test.describe('Withings', () => {
     await expect(page.getByText('87.2 kg')).toBeVisible();
     await expect(page.getByText('21.8 kg')).toBeVisible();
     await expect(page.getByText('35.3 %')).toBeVisible();
+  });
+
+  test('should not crash when withings returns no weight measurement', async ({ page }) => {
+    await cleanupDb();
+    await populateOAuthClients();
+    await setWithingsMeasures([
+      { value: 352664, type: 6, unit: -4 },
+      { value: 217634, type: 8, unit: -4 },
+    ]);
+
+    await page.goto('/');
+    await expect(page.getByRole('heading', { name: 'Weight' })).toBeVisible();
+
+    expect(await getWeightRows()).toEqual([]);
+  });
+
+  test('should persist weight when fat measurements are missing', async ({ page }) => {
+    await cleanupDb();
+    await populateOAuthClients();
+    await setWithingsMeasures([
+      { value: 871532, type: 1, unit: -4 },
+    ]);
+
+    await page.goto('/');
+    await expect(page.getByRole('heading', { name: 'Weight' })).toBeVisible();
+    await expect(page.getByText('87.2 kg')).toBeVisible();
+
+    const rows = await getWeightRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].fat_ratio).toBeNull();
+    expect(rows[0].fat_mass_weight).toBeNull();
   });
 });

--- a/test/tests/withings.spec.ts
+++ b/test/tests/withings.spec.ts
@@ -42,8 +42,12 @@ test.describe('Withings', () => {
       { value: 217634, type: 8, unit: -4 },
     ]);
 
+    const syncResponsePromise = page.waitForResponse(
+      (response) => response.url().endsWith('/api/withings/sync') && response.request().method() === 'POST'
+    );
     await page.goto('/');
-    await expect(page.getByRole('heading', { name: 'Weight' })).toBeVisible();
+    const syncResponse = await syncResponsePromise;
+    expect(syncResponse.status()).toBe(200);
 
     expect(await getWeightRows()).toEqual([]);
   });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -345,3 +345,36 @@ export async function resetStravaActivities() {
     throw new Error(`Failed to reset Strava activities: ${response.status}`);
   }
 }
+
+export type WithingsMeasure = {
+  value: number;
+  type: number;
+  unit: number;
+};
+
+export async function setWithingsMeasures(measures: WithingsMeasure[]) {
+  const response = await fetch('http://localhost:8180/withings/test/measure', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ measures }),
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to set Withings measures: ${response.status}`);
+  }
+}
+
+export async function resetWithingsMeasures() {
+  const response = await fetch('http://localhost:8180/withings/test/reset', {
+    method: 'POST',
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to reset Withings measures: ${response.status}`);
+  }
+}
+
+export async function getWeightRows() {
+  const result = await query(
+    'SELECT created_at, weight, fat_ratio, fat_mass_weight FROM training_log.weight ORDER BY created_at ASC'
+  );
+  return result.rows;
+}


### PR DESCRIPTION
## Summary
This PR makes fat ratio and fat mass weight measurements optional when processing Withings data, allowing the application to handle incomplete measurement data gracefully.

## Key Changes
- **Mock Withings Server**: Added test endpoints to configure measure scenarios
  - New `setMeasureScenario` endpoint to override default measurements
  - New `resetMeasureScenario` endpoint to restore defaults
  - Extracted hardcoded measures into `DEFAULT_MEASURES` constant for reusability
  - Added JSON body parsing support

- **Weight Service**: Updated measurement processing logic
  - Weight measurement is now required; measurement groups without weight are skipped
  - Fat ratio and fat mass weight are now optional (nullable)
  - Changed from `orElseThrow()` to `orElse(null)` for optional measurements

- **Weight Entity**: Updated database schema
  - Changed `fatMassWeight` and `fatRatio` from `float` to `Float` (nullable)

- **Test Infrastructure**: Added utilities for testing incomplete measurement scenarios
  - New `setWithingsMeasures()` helper to configure test measurements
  - New `resetWithingsMeasures()` helper to restore defaults
  - New `getWeightRows()` helper to query persisted weight data
  - Added test cases for missing weight and missing fat measurements

- **Test Fixtures**: Updated test setup to reset Withings measures between tests

## Implementation Details
The changes allow the application to persist weight measurements even when fat-related measurements are missing from the Withings API response, improving robustness when dealing with incomplete data.

https://claude.ai/code/session_013sBvX4qqbg77B7K4ZrHrJw