### PR TITLE
Expand podium panel with segment details and performance metrics

### DIFF
--- a/client/src/app/ride/ride.component.css
+++ b/client/src/app/ride/ride.component.css
@@ -44,6 +44,20 @@ h2 {
   background: var(--mat-sys-surface-container);
   box-shadow: 0 1px 3px rgb(0 0 0 / 0.2);
   border-left: 4px solid var(--podium-medal-color);
+  color: inherit;
+  text-decoration: none;
+  transition: background-color 120ms ease, box-shadow 120ms ease;
+}
+
+.podium-panel:hover,
+.podium-panel:focus-visible {
+  background: var(--mat-sys-surface-container-high, var(--mat-sys-surface-container));
+  box-shadow: 0 2px 6px rgb(0 0 0 / 0.3);
+}
+
+.podium-panel:focus-visible {
+  outline: 2px solid var(--podium-medal-color);
+  outline-offset: 2px;
 }
 
 .podium-panel[data-position="1"] {

--- a/client/src/app/ride/ride.component.css
+++ b/client/src/app/ride/ride.component.css
@@ -33,29 +33,114 @@ h2 {
   font-size: 14px;
 }
 
-.podium-banner {
+.podium-panel {
+  --podium-medal-color: #cd7f32;
+  --podium-medal-glow: rgb(205 127 50 / 0.25);
+  display: grid;
+  gap: 16px;
+  padding: 20px;
+  margin: 0 0 24px;
+  border-radius: 0.75rem;
+  background: var(--mat-sys-surface-container);
+  box-shadow: 0 1px 3px rgb(0 0 0 / 0.2);
+  border-left: 4px solid var(--podium-medal-color);
+}
+
+.podium-panel[data-position="1"] {
+  --podium-medal-color: #ffd700;
+  --podium-medal-glow: rgb(255 215 0 / 0.3);
+}
+
+.podium-panel[data-position="2"] {
+  --podium-medal-color: #c0c0c0;
+  --podium-medal-glow: rgb(192 192 192 / 0.3);
+}
+
+.podium-header {
   display: flex;
   align-items: center;
   gap: 16px;
-  padding: 16px 20px;
-  margin: 0 0 24px;
-  border-radius: 12px;
-  background: var(--mat-sys-primary-container, #00415a);
-  color: var(--mat-sys-on-primary-container, #d6f0ff);
-  box-shadow: 0 1px 3px rgb(0 0 0 / 0.2);
 }
 
-.podium-banner mat-icon {
+.podium-medal {
   flex-shrink: 0;
-  width: 32px;
-  height: 32px;
-  font-size: 32px;
-  color: var(--mat-sys-tertiary, #f5c518);
+  width: 40px;
+  height: 40px;
+  font-size: 40px;
+  color: var(--podium-medal-color);
+  filter: drop-shadow(0 0 6px var(--podium-medal-glow));
 }
 
-.podium-banner .podium-title {
+.podium-meta {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.podium-title {
   margin: 0;
+  color: var(--mat-sys-on-primary);
   font-size: 16px;
   font-weight: 600;
   line-height: 1.3;
+}
+
+.podium-subtitle {
+  margin: 0;
+  color: var(--bt-text-muted);
+  font-size: 13px;
+}
+
+.podium-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(90px, 1fr));
+  gap: 12px;
+  margin: 0;
+}
+
+.podium-stats > div {
+  display: grid;
+  gap: 2px;
+}
+
+.podium-stats dt {
+  color: var(--bt-text-muted);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 600;
+}
+
+.podium-stats dd {
+  margin: 0;
+  color: var(--mat-sys-on-primary);
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.podium-gaps {
+  list-style: none;
+  margin: 0;
+  padding: 12px 0 0;
+  border-top: 1px solid var(--mat-sys-outline-variant, rgb(255 255 255 / 0.08));
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.podium-gaps li {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  font-size: 13px;
+}
+
+.gap-label {
+  color: var(--bt-text-muted);
+}
+
+.gap-value {
+  color: var(--mat-sys-on-primary);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
 }

--- a/client/src/app/ride/ride.component.html
+++ b/client/src/app/ride/ride.component.html
@@ -5,12 +5,15 @@
 <div class="page-loading"><bt-bar-loader /></div>
 } @else if (today && period) {
 @if (podium) {
-<article
+<a
   class="podium-panel"
   data-testid="podium-banner"
   [attr.data-period]="podium.period"
   [attr.data-position]="podium.position"
-  [attr.aria-label]="podium.message"
+  [attr.aria-label]="podium.message + ' — open Strava segment'"
+  [href]="podium.segmentUrl"
+  target="_blank"
+  rel="noopener noreferrer"
 >
   <header class="podium-header">
     <mat-icon class="podium-medal" aria-hidden="true">emoji_events</mat-icon>
@@ -71,7 +74,7 @@
     }
   </ul>
   }
-</article>
+</a>
 }
 @if ((period.time ?? 0) > 0) {
 <section>

--- a/client/src/app/ride/ride.component.html
+++ b/client/src/app/ride/ride.component.html
@@ -5,17 +5,73 @@
 <div class="page-loading"><bt-bar-loader /></div>
 } @else if (today && period) {
 @if (podium) {
-<aside
-  class="podium-banner"
+<article
+  class="podium-panel"
   data-testid="podium-banner"
   [attr.data-period]="podium.period"
   [attr.data-position]="podium.position"
+  [attr.aria-label]="podium.message"
 >
-  <mat-icon aria-hidden="true">emoji_events</mat-icon>
-  <div class="podium-text">
-    <p class="podium-title">{{ podium.message }}</p>
-  </div>
-</aside>
+  <header class="podium-header">
+    <mat-icon class="podium-medal" aria-hidden="true">emoji_events</mat-icon>
+    <div class="podium-meta">
+      <p class="podium-title">{{ podium.message }}</p>
+      <p class="podium-subtitle">{{ podium.segmentName }}</p>
+    </div>
+  </header>
+  <dl class="podium-stats">
+    <div>
+      <dt>Length</dt>
+      <dd data-testid="podium-distance">
+        {{ podium.distance | measurementWithUnit : "km" : 2 : 1000 }}
+      </dd>
+    </div>
+    <div>
+      <dt>Time</dt>
+      <dd data-testid="podium-time">{{ formatDuration(podium.elapsedTime) }}</dd>
+    </div>
+    <div>
+      <dt>Elevation</dt>
+      <dd data-testid="podium-elevation">
+        {{ podium.elevationGain | measurementWithUnit : "m" : 0 }}
+      </dd>
+    </div>
+    @if (podium.averageWatts) {
+    <div>
+      <dt>Avg watts</dt>
+      <dd data-testid="podium-watts">
+        {{ podium.averageWatts | measurementWithUnit : "W" : 0 }}
+      </dd>
+    </div>
+    } @if (podium.averageWattsPerKg) {
+    <div>
+      <dt>Watts / kg</dt>
+      <dd data-testid="podium-watts-per-kg">
+        {{ podium.averageWattsPerKg | number : "1.1-1" }} W/kg
+      </dd>
+    </div>
+    }
+  </dl>
+  @if (podium.gapToFaster != null || podium.gapToSlower != null) {
+  <ul class="podium-gaps">
+    @if (podium.gapToFaster != null && podium.fasterPosition) {
+    <li data-testid="podium-gap-faster">
+      <span class="gap-label"
+        >{{ formatPosition(podium.fasterPosition) }} place</span
+      >
+      <span class="gap-value">-{{ formatDuration(podium.gapToFaster) }}</span>
+    </li>
+    } @if (podium.gapToSlower != null && podium.slowerPosition) {
+    <li data-testid="podium-gap-slower">
+      <span class="gap-label"
+        >{{ formatPosition(podium.slowerPosition) }} place</span
+      >
+      <span class="gap-value">+{{ formatDuration(podium.gapToSlower) }}</span>
+    </li>
+    }
+  </ul>
+  }
+</article>
 }
 @if ((period.time ?? 0) > 0) {
 <section>

--- a/client/src/app/ride/ride.component.ts
+++ b/client/src/app/ride/ride.component.ts
@@ -1,3 +1,4 @@
+import { DecimalPipe } from '@angular/common';
 import { Component, inject, resource } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
@@ -9,7 +10,7 @@ import { MeasurementWithUnitPipe } from '../utils/measurement-with-unit.pipe';
 
 @Component({
   standalone: true,
-  imports: [MatIconModule, BarLoaderComponent, MeasurementWithUnitPipe],
+  imports: [DecimalPipe, MatIconModule, BarLoaderComponent, MeasurementWithUnitPipe],
   selector: 'app-ride',
   templateUrl: './ride.component.html',
   styleUrl: './ride.component.css',
@@ -32,4 +33,17 @@ export class RideComponent {
   readonly podiumMessage = resource({
     loader: () => this.rideService.getPodiumMessage(),
   });
+
+  formatDuration(seconds: number): string {
+    const minutes = Math.floor(seconds / 60);
+    const remaining = seconds - minutes * 60;
+    return `${minutes}:${remaining.toString().padStart(2, '0')}`;
+  }
+
+  formatPosition(position: number): string {
+    if (position === 1) return '1st';
+    if (position === 2) return '2nd';
+    if (position === 3) return '3rd';
+    return `${position}th`;
+  }
 }

--- a/client/src/app/ride/ride.service.ts
+++ b/client/src/app/ride/ride.service.ts
@@ -16,6 +16,7 @@ export type PodiumPeriod = 'WEEK' | 'MONTH' | 'ALL_TIME';
 
 export type PodiumMessage = {
   segmentName: string;
+  segmentUrl: string;
   period: PodiumPeriod;
   position: number;
   message: string;

--- a/client/src/app/ride/ride.service.ts
+++ b/client/src/app/ride/ride.service.ts
@@ -19,6 +19,16 @@ export type PodiumMessage = {
   period: PodiumPeriod;
   position: number;
   message: string;
+  distance: number;
+  elapsedTime: number;
+  averageGrade: number;
+  elevationGain: number;
+  averageWatts?: number;
+  averageWattsPerKg?: number;
+  fasterPosition?: number;
+  gapToFaster?: number;
+  slowerPosition?: number;
+  gapToSlower?: number;
 };
 
 @Injectable({ providedIn: 'root' })

--- a/mock_strava_server/src/activities.ts
+++ b/mock_strava_server/src/activities.ts
@@ -7,6 +7,7 @@ type PushedSegmentEffort = {
   segmentDistance: number;
   segmentAverageGrade: number;
   elapsedTime: number;
+  averageWatts: number | null;
 };
 
 type PushedActivity = {
@@ -40,6 +41,7 @@ export function pushActivity(req: Request, res: Response) {
       segmentDistance: effort.segmentDistance ?? 500,
       segmentAverageGrade: effort.segmentAverageGrade ?? 4,
       elapsedTime: effort.elapsedTime ?? 120,
+      averageWatts: effort.averageWatts ?? 220,
     })
   );
 
@@ -296,6 +298,7 @@ export function getActivity(req: Request, res: Response) {
         start_date: effortStart.toISOString(),
         start_date_local: effortStart.toISOString(),
         distance: effort.segmentDistance,
+        average_watts: effort.averageWatts,
         segment: {
           id: effort.segmentId,
           resource_state: 2,

--- a/server/src/main/java/mucsi96/traininglog/segments/PodiumService.java
+++ b/server/src/main/java/mucsi96/traininglog/segments/PodiumService.java
@@ -14,6 +14,8 @@ import org.springframework.stereotype.Service;
 import lombok.RequiredArgsConstructor;
 import mucsi96.traininglog.api.PodiumMessage;
 import mucsi96.traininglog.api.PodiumMessage.PeriodEnum;
+import mucsi96.traininglog.weight.Weight;
+import mucsi96.traininglog.weight.WeightRepository;
 
 @Service
 @RequiredArgsConstructor
@@ -21,6 +23,7 @@ public class PodiumService {
   private static final int PODIUM_SIZE = 3;
 
   private final SegmentEffortRepository segmentEffortRepository;
+  private final WeightRepository weightRepository;
   private final Clock clock;
 
   public Optional<PodiumMessage> getTodayPodium(ZoneId zoneId) {
@@ -70,7 +73,7 @@ public class PodiumService {
     for (SegmentEffort ranked : rankedEfforts) {
       if (ranked.getId() == effort.getId()) {
         if (position <= PODIUM_SIZE) {
-          return Optional.of(new PodiumPlacement(effort, period, position));
+          return Optional.of(new PodiumPlacement(effort, period, position, rankedEfforts));
         }
         return Optional.empty();
       }
@@ -103,16 +106,49 @@ public class PodiumService {
       case 3 -> "3rd place";
       default -> placement.position() + "th place";
     };
+    SegmentEffort effort = placement.effort();
     String message = String.format("%s %s on %s",
-        podiumLabel, periodLabel, placement.effort().getSegmentName());
+        podiumLabel, periodLabel, effort.getSegmentName());
+
+    int position = placement.position();
+    List<SegmentEffort> ranked = placement.rankedEfforts();
+    SegmentEffort faster = position >= 2 ? ranked.get(position - 2) : null;
+    SegmentEffort slower = ranked.size() > position ? ranked.get(position) : null;
+
+    float elevationGain = effort.getSegmentDistance() * effort.getSegmentAverageGrade() / 100f;
+    Float averageWattsPerKg = wattsPerKg(effort);
+
     return PodiumMessage.builder()
-        .segmentName(placement.effort().getSegmentName())
+        .segmentName(effort.getSegmentName())
         .period(placement.period())
-        .position(placement.position())
+        .position(position)
         .message(message)
+        .distance(effort.getSegmentDistance())
+        .elapsedTime(effort.getElapsedTime())
+        .averageGrade(effort.getSegmentAverageGrade())
+        .elevationGain(elevationGain)
+        .averageWatts(effort.getAverageWatts())
+        .averageWattsPerKg(averageWattsPerKg)
+        .fasterPosition(faster != null ? position - 1 : null)
+        .gapToFaster(faster != null ? effort.getElapsedTime() - faster.getElapsedTime() : null)
+        .slowerPosition(slower != null ? position + 1 : null)
+        .gapToSlower(slower != null ? slower.getElapsedTime() - effort.getElapsedTime() : null)
         .build();
   }
 
-  private record PodiumPlacement(SegmentEffort effort, PeriodEnum period, int position) {
+  private Float wattsPerKg(SegmentEffort effort) {
+    if (effort.getAverageWatts() == null) {
+      return null;
+    }
+    return weightRepository
+        .findFirstByCreatedAtBeforeOrderByCreatedAtDesc(effort.getStartDate().plusDays(1))
+        .map(Weight::getWeight)
+        .filter(weight -> weight > 0)
+        .map(weight -> effort.getAverageWatts() / weight)
+        .orElse(null);
+  }
+
+  private record PodiumPlacement(SegmentEffort effort, PeriodEnum period, int position,
+      List<SegmentEffort> rankedEfforts) {
   }
 }

--- a/server/src/main/java/mucsi96/traininglog/segments/PodiumService.java
+++ b/server/src/main/java/mucsi96/traininglog/segments/PodiumService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import lombok.RequiredArgsConstructor;
 import mucsi96.traininglog.api.PodiumMessage;
 import mucsi96.traininglog.api.PodiumMessage.PeriodEnum;
+import mucsi96.traininglog.strava.StravaConfiguration;
 import mucsi96.traininglog.weight.Weight;
 import mucsi96.traininglog.weight.WeightRepository;
 
@@ -24,6 +25,7 @@ public class PodiumService {
 
   private final SegmentEffortRepository segmentEffortRepository;
   private final WeightRepository weightRepository;
+  private final StravaConfiguration stravaConfiguration;
   private final Clock clock;
 
   public Optional<PodiumMessage> getTodayPodium(ZoneId zoneId) {
@@ -118,8 +120,11 @@ public class PodiumService {
     float elevationGain = effort.getSegmentDistance() * effort.getSegmentAverageGrade() / 100f;
     Float averageWattsPerKg = wattsPerKg(effort);
 
+    String segmentUrl = stravaConfiguration.getApiUri() + "/segments/" + effort.getSegmentId();
+
     return PodiumMessage.builder()
         .segmentName(effort.getSegmentName())
+        .segmentUrl(segmentUrl)
         .period(placement.period())
         .position(position)
         .message(message)

--- a/server/src/main/java/mucsi96/traininglog/segments/SegmentEffort.java
+++ b/server/src/main/java/mucsi96/traininglog/segments/SegmentEffort.java
@@ -37,6 +37,9 @@ public class SegmentEffort {
   private int elapsedTime;
 
   @Column
+  private Float averageWatts;
+
+  @Column
   private ZonedDateTime startDate;
 
   @Column

--- a/server/src/main/java/mucsi96/traininglog/strava/StravaActivityService.java
+++ b/server/src/main/java/mucsi96/traininglog/strava/StravaActivityService.java
@@ -178,6 +178,7 @@ public class StravaActivityService {
         .segmentDistance(segment.getDistance())
         .segmentAverageGrade(segment.getAverageGrade())
         .elapsedTime(effort.getElapsedTime())
+        .averageWatts(effort.getAverageWatts())
         .startDate(effort.getStartDate().atZoneSameInstant(ZoneOffset.UTC))
         .rideCreatedAt(rideCreatedAt)
         .build();

--- a/server/src/main/resources/api.yml
+++ b/server/src/main/resources/api.yml
@@ -524,6 +524,10 @@ components:
         - period
         - position
         - message
+        - distance
+        - elapsedTime
+        - averageGrade
+        - elevationGain
       properties:
         segmentName:
           type: string
@@ -540,3 +544,33 @@ components:
           maximum: 3
         message:
           type: string
+        distance:
+          type: number
+          format: float
+        elapsedTime:
+          type: integer
+          format: int32
+        averageGrade:
+          type: number
+          format: float
+        elevationGain:
+          type: number
+          format: float
+        averageWatts:
+          type: number
+          format: float
+        averageWattsPerKg:
+          type: number
+          format: float
+        fasterPosition:
+          type: integer
+          format: int32
+        gapToFaster:
+          type: integer
+          format: int32
+        slowerPosition:
+          type: integer
+          format: int32
+        gapToSlower:
+          type: integer
+          format: int32

--- a/server/src/main/resources/api.yml
+++ b/server/src/main/resources/api.yml
@@ -534,7 +534,6 @@ components:
           type: string
         segmentUrl:
           type: string
-          format: uri
         period:
           type: string
           enum:

--- a/server/src/main/resources/api.yml
+++ b/server/src/main/resources/api.yml
@@ -521,6 +521,7 @@ components:
       type: object
       required:
         - segmentName
+        - segmentUrl
         - period
         - position
         - message
@@ -531,6 +532,9 @@ components:
       properties:
         segmentName:
           type: string
+        segmentUrl:
+          type: string
+          format: uri
         period:
           type: string
           enum:

--- a/server/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/server/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -569,3 +569,16 @@ databaseChangeLog:
                   defaultValueDate: '1970-01-01T00:00:00'
                   constraints:
                     nullable: false
+
+  - changeSet:
+      id: 21-add-average-watts-to-segment-effort
+      author: mucsi96
+      changes:
+        - addColumn:
+            tableName: segment_effort
+            columns:
+              - column:
+                  name: average_watts
+                  type: float4
+                  constraints:
+                    nullable: true

--- a/server/src/main/resources/strava.yml
+++ b/server/src/main/resources/strava.yml
@@ -297,6 +297,9 @@ paths:
                         distance:
                           type: number
                           format: float
+                        average_watts:
+                          type: number
+                          format: float
                         segment:
                           title: StravaSegment
                           type: object

--- a/test/tests/podium.spec.ts
+++ b/test/tests/podium.spec.ts
@@ -131,6 +131,9 @@ test.describe('Podium messages', () => {
     await expect(panel).toBeVisible();
     await expect(panel).toContainText('2nd place all-time on UndAbflug');
     await expect(panel).toHaveAttribute('data-position', '2');
+    await expect(panel).toHaveAttribute('href', /\/segments\/42$/);
+    await expect(panel).toHaveAttribute('target', '_blank');
+    await expect(panel).toHaveAttribute('rel', /noopener/);
 
     await expect(page.getByTestId('podium-distance')).toContainText('1.2 km');
     await expect(page.getByTestId('podium-time')).toContainText('3:30');

--- a/test/tests/podium.spec.ts
+++ b/test/tests/podium.spec.ts
@@ -3,6 +3,7 @@ import {
   cleanupDb,
   getSegmentEffortRows,
   insertSegmentEffort,
+  insertWeight,
   populateOAuthClients,
   pushStravaActivity,
 } from '../utils';
@@ -85,5 +86,57 @@ test.describe('Podium messages', () => {
     await page.goto('/');
     await expect(page.getByRole('heading', { name: 'Calories' })).toBeVisible();
     await expect(page.getByTestId('podium-banner')).toHaveCount(0);
+  });
+
+  test('renders segment details and neighbour gaps on the podium panel', async ({
+    page,
+  }) => {
+    await insertWeight(1, 70, 0.18, 12.6);
+    for (const [daysAgo, elapsed, effortId] of [
+      [3, 200, 3001],
+      [4, 220, 3002],
+      [5, 260, 3003],
+    ] as const) {
+      await insertSegmentEffort({
+        id: effortId,
+        segmentId: 42,
+        segmentName: 'UndAbflug',
+        segmentDistance: 1200,
+        segmentAverageGrade: 6,
+        elapsedTime: elapsed,
+        daysAgo,
+        averageWatts: 240,
+      });
+    }
+
+    await pushStravaActivity({
+      segmentEfforts: [
+        {
+          id: 9101,
+          segmentId: 42,
+          segmentName: 'UndAbflug',
+          segmentDistance: 1200,
+          segmentAverageGrade: 6,
+          elapsedTime: 210,
+          averageWatts: 280,
+        },
+      ],
+    });
+
+    await page.goto('/');
+    const panel = page.getByTestId('podium-banner');
+    await expect(panel).toBeVisible();
+    await expect(panel).toContainText('2nd place all-time on UndAbflug');
+    await expect(panel).toHaveAttribute('data-position', '2');
+
+    await expect(page.getByTestId('podium-distance')).toContainText('1.2 km');
+    await expect(page.getByTestId('podium-time')).toContainText('3:30');
+    await expect(page.getByTestId('podium-elevation')).toContainText('72 m');
+    await expect(page.getByTestId('podium-watts')).toContainText('280 W');
+    await expect(page.getByTestId('podium-watts-per-kg')).toContainText('4.0 W/kg');
+    await expect(page.getByTestId('podium-gap-faster')).toContainText('1st place');
+    await expect(page.getByTestId('podium-gap-faster')).toContainText('-0:10');
+    await expect(page.getByTestId('podium-gap-slower')).toContainText('3rd place');
+    await expect(page.getByTestId('podium-gap-slower')).toContainText('+0:10');
   });
 });

--- a/test/tests/podium.spec.ts
+++ b/test/tests/podium.spec.ts
@@ -3,9 +3,9 @@ import {
   cleanupDb,
   getSegmentEffortRows,
   insertSegmentEffort,
-  insertWeight,
   populateOAuthClients,
   pushStravaActivity,
+  setWithingsMeasures,
 } from '../utils';
 
 test.describe('Podium messages', () => {
@@ -91,7 +91,10 @@ test.describe('Podium messages', () => {
   test('renders segment details and neighbour gaps on the podium panel', async ({
     page,
   }) => {
-    await insertWeight(1, 70, 0.18, 12.6);
+    // Strava sync triggers a Withings sync first, which persists today's
+    // weight from the mock. Lock today's weight to 70 kg so watts/kg is
+    // deterministic (280 W / 70 kg = 4.0 W/kg).
+    await setWithingsMeasures([{ value: 700000, type: 1, unit: -4 }]);
     for (const [daysAgo, elapsed, effortId] of [
       [3, 200, 3001],
       [4, 220, 3002],

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -161,14 +161,15 @@ export async function insertSegmentEffort(
     segmentAverageGrade: number;
     elapsedTime: number;
     daysAgo: number;
+    averageWatts?: number | null;
   }
 ) {
   const startDate = new Date(Date.now() - effort.daysAgo * 86400000);
   await query(
     `INSERT INTO training_log.segment_effort (
       id, segment_id, segment_name, segment_distance, segment_average_grade,
-      elapsed_time, start_date, ride_created_at
-    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $7)`,
+      elapsed_time, average_watts, start_date, ride_created_at
+    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $8)`,
     [
       effort.id,
       effort.segmentId,
@@ -176,6 +177,7 @@ export async function insertSegmentEffort(
       effort.segmentDistance,
       effort.segmentAverageGrade,
       effort.elapsedTime,
+      effort.averageWatts ?? null,
       startDate,
     ]
   );
@@ -184,7 +186,7 @@ export async function insertSegmentEffort(
 export async function getSegmentEffortRows() {
   const result = await query(
     `SELECT id, segment_id, segment_name, segment_distance, segment_average_grade,
-            elapsed_time, start_date
+            elapsed_time, average_watts, start_date
      FROM training_log.segment_effort ORDER BY id ASC`
   );
   return result.rows;
@@ -294,6 +296,7 @@ export type PushStravaSegmentEffortOptions = {
   segmentDistance?: number;
   segmentAverageGrade?: number;
   elapsedTime?: number;
+  averageWatts?: number | null;
 };
 
 export type PushStravaActivityOptions = {


### PR DESCRIPTION
## Summary
Enhanced the podium panel to display comprehensive segment details and performance metrics, including distance, elevation gain, power output, and gaps to neighboring positions on the leaderboard.

## Key Changes

**Frontend (Angular)**
- Redesigned podium panel layout from simple banner to detailed card with multiple sections
- Added segment metadata display (name, distance, elevation gain, elapsed time)
- Integrated power metrics (average watts and watts/kg) when available
- Implemented gap visualization showing time differences to faster/slower efforts
- Updated styling with position-based medal colors (gold for 1st, silver for 2nd, bronze for 3rd)
- Added helper methods `formatDuration()` and `formatPosition()` for consistent formatting

**Backend (Java)**
- Extended `PodiumMessage` API response with segment and performance data:
  - Distance, elapsed time, average grade, elevation gain
  - Average watts and watts/kg calculations
  - Neighboring position gaps (faster/slower)
- Enhanced `PodiumService` to calculate watts/kg using weight history
- Modified `PodiumPlacement` record to include ranked efforts list for gap calculations
- Added `average_watts` column to `segment_effort` table via database migration

**Testing & Data**
- Updated test utilities to support `average_watts` in segment effort insertion
- Added comprehensive E2E test validating all podium panel details and gap calculations
- Extended mock Strava server to handle average watts in segment efforts

## Implementation Details
- Elevation gain is calculated from segment distance and average grade
- Watts/kg is computed by querying the user's weight on the effort date
- Gap calculations compare elapsed times between ranked efforts
- Styling uses CSS custom properties for medal colors with glow effects
- Panel uses semantic HTML (`<article>`, `<header>`, `<dl>`) for accessibility

https://claude.ai/code/session_01NYR7VHohPJCJrmr9rP3JWY