### PR TITLE
Filter out segments with negative elevation during Strava sync

### DIFF
--- a/server/src/main/java/mucsi96/traininglog/strava/StravaActivityService.java
+++ b/server/src/main/java/mucsi96/traininglog/strava/StravaActivityService.java
@@ -153,6 +153,7 @@ public class StravaActivityService {
           .orElse(List.of())
           .stream()
           .map(effort -> toSegmentEffort(effort, rideCreatedAt))
+          .filter(effort -> effort.getSegmentAverageGrade() >= 0)
           .toList();
       efforts.forEach(effort -> log.info(
           "Strava segment effort to persist: id={} segment_id={} segment_name={} distance_m={} "

--- a/test/tests/podium.spec.ts
+++ b/test/tests/podium.spec.ts
@@ -88,6 +88,35 @@ test.describe('Podium messages', () => {
     await expect(page.getByTestId('podium-banner')).toHaveCount(0);
   });
 
+  test('skips segments with negative elevation when syncing', async ({ page }) => {
+    await pushStravaActivity({
+      segmentEfforts: [
+        {
+          id: 8001,
+          segmentId: 81,
+          segmentName: 'Uphill Climb',
+          segmentDistance: 500,
+          segmentAverageGrade: 5,
+          elapsedTime: 120,
+        },
+        {
+          id: 8002,
+          segmentId: 82,
+          segmentName: 'Downhill Descent',
+          segmentDistance: 500,
+          segmentAverageGrade: -5,
+          elapsedTime: 80,
+        },
+      ],
+    });
+
+    await page.goto('/');
+    await expect(page.getByRole('heading', { name: 'Calories' })).toBeVisible();
+
+    const efforts = await getSegmentEffortRows();
+    expect(efforts.map((row) => Number(row.id))).toEqual([8001]);
+  });
+
   test('renders segment details and neighbour gaps on the podium panel', async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary
This change filters out segment efforts with negative average grades (downhill segments) during Strava activity synchronization, ensuring only uphill climbs are persisted and displayed in the podium.

## Key Changes
- Added a filter in `StravaActivityService.getTodayRides()` to exclude segment efforts where `segmentAverageGrade < 0`
- Added test case to verify that downhill segments (negative grade) are skipped while uphill segments are retained during sync

## Implementation Details
The filter is applied at the stream level during the mapping of Strava segment efforts, ensuring that only segments with non-negative elevation grades are included in the final list before persistence. This aligns with the podium's focus on climbing achievements.

https://claude.ai/code/session_01N9JmxFJSP7xagSfhgJwYMa