### PR TITLE
Filter out segment efforts shorter than 2 minutes during sync

### DIFF
--- a/server/src/main/java/mucsi96/traininglog/strava/StravaActivityService.java
+++ b/server/src/main/java/mucsi96/traininglog/strava/StravaActivityService.java
@@ -154,6 +154,7 @@ public class StravaActivityService {
           .stream()
           .map(effort -> toSegmentEffort(effort, rideCreatedAt))
           .filter(effort -> effort.getSegmentAverageGrade() >= 0)
+          .filter(effort -> effort.getElapsedTime() >= 120)
           .toList();
       efforts.forEach(effort -> log.info(
           "Strava segment effort to persist: id={} segment_id={} segment_name={} distance_m={} "

--- a/test/tests/podium.spec.ts
+++ b/test/tests/podium.spec.ts
@@ -50,7 +50,7 @@ test.describe('Podium messages', () => {
           segmentName: 'Flat Loop',
           segmentDistance: 1000,
           segmentAverageGrade: 1,
-          elapsedTime: 100,
+          elapsedTime: 150,
         },
         {
           id: 9002,
@@ -115,6 +115,35 @@ test.describe('Podium messages', () => {
 
     const efforts = await getSegmentEffortRows();
     expect(efforts.map((row) => Number(row.id))).toEqual([8001]);
+  });
+
+  test('skips segments shorter than two minutes when syncing', async ({ page }) => {
+    await pushStravaActivity({
+      segmentEfforts: [
+        {
+          id: 7001,
+          segmentId: 71,
+          segmentName: 'Long Climb',
+          segmentDistance: 1000,
+          segmentAverageGrade: 5,
+          elapsedTime: 120,
+        },
+        {
+          id: 7002,
+          segmentId: 72,
+          segmentName: 'Sprint Section',
+          segmentDistance: 200,
+          segmentAverageGrade: 3,
+          elapsedTime: 119,
+        },
+      ],
+    });
+
+    await page.goto('/');
+    await expect(page.getByRole('heading', { name: 'Calories' })).toBeVisible();
+
+    const efforts = await getSegmentEffortRows();
+    expect(efforts.map((row) => Number(row.id))).toEqual([7001]);
   });
 
   test('renders segment details and neighbour gaps on the podium panel', async ({


### PR DESCRIPTION
## Summary
Added filtering logic to exclude segment efforts shorter than 2 minutes (120 seconds) when syncing Strava activities. This prevents short, potentially low-quality efforts from cluttering the podium.

## Changes
- **Server**: Added elapsed time filter (`>= 120` seconds) in `StravaActivityService.getTodayRides()` to exclude short segment efforts during the sync process
- **Tests**: Added test case `skips segments shorter than two minutes when syncing` to verify that only efforts meeting the minimum duration threshold are persisted
- **Test data**: Updated existing test data to use 150 seconds (previously 100) to comply with the new minimum duration requirement

## Implementation Details
The filter is applied in the stream pipeline after the existing grade filter, ensuring only segment efforts that meet both criteria (non-negative grade AND >= 120 seconds elapsed time) are persisted to the database.

https://claude.ai/code/session_017EQdsqdX823KmX423MN2dn