### PR TITLE
Add wanted books list and book editing functionality

### DIFF
--- a/client/src/app/reading/reading-library.component.css
+++ b/client/src/app/reading/reading-library.component.css
@@ -35,6 +35,32 @@ h2 {
   opacity: 0.7;
 }
 
+.book--wanted {
+  opacity: 0.85;
+  border: 1px dashed var(--mat-sys-outline-variant);
+  background: transparent;
+}
+
+.book-group {
+  display: grid;
+  gap: 8px;
+}
+
+.book-group h3 {
+  margin: 0;
+  color: var(--bt-text-muted);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.book-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
 .book-header {
   display: flex;
   align-items: flex-start;

--- a/client/src/app/reading/reading-library.component.html
+++ b/client/src/app/reading/reading-library.component.html
@@ -4,17 +4,104 @@
 <section class="library" aria-labelledby="reading-library-heading">
   <h2 id="reading-library-heading">Books</h2>
 
-  <div class="books">
-    @if (inProgressBooks().length === 0 && completedBooks().length === 0 &&
-    !addingBook()) {
-    <p class="empty">No books yet. Add your first one to get started.</p>
-    } @for (book of inProgressBooks(); track book.id) {
-    <article class="book" [attr.aria-label]="ariaForBook(book)">
-      <header class="book-header">
-        <div class="book-meta">
-          <h3 class="book-title">{{ book.title }}</h3>
-          <p class="book-author">{{ book.author }}</p>
-        </div>
+  @if (inProgressBooks().length === 0 && completedBooks().length === 0 &&
+  wantedBooks().length === 0 && !addingBook()) {
+  <p class="empty">No books yet. Add your first one to get started.</p>
+  }
+
+  @if (inProgressBooks().length > 0) {
+    <div class="book-group">
+      <h3>Reading in progress</h3>
+      <div class="books">
+        @for (book of inProgressBooks(); track book.id) {
+          <ng-container
+            *ngTemplateOutlet="
+              bookCard;
+              context: { $implicit: book, variant: 'in-progress' }
+            "
+          ></ng-container>
+        }
+      </div>
+    </div>
+  }
+
+  @if (completedBooks().length > 0) {
+    <div class="book-group">
+      <h3>Already read</h3>
+      <div class="books">
+        @for (book of completedBooks(); track book.id) {
+          <ng-container
+            *ngTemplateOutlet="
+              bookCard;
+              context: { $implicit: book, variant: 'completed' }
+            "
+          ></ng-container>
+        }
+      </div>
+    </div>
+  }
+
+  @if (wantedBooks().length > 0) {
+    <div class="book-group">
+      <h3>Wanted list</h3>
+      <div class="books">
+        @for (book of wantedBooks(); track book.id) {
+          <ng-container
+            *ngTemplateOutlet="
+              bookCard;
+              context: { $implicit: book, variant: 'wanted' }
+            "
+          ></ng-container>
+        }
+      </div>
+    </div>
+  }
+
+  @if (addingBook()) {
+  <ng-container
+    *ngTemplateOutlet="bookForm; context: { mode: 'add' }"
+  ></ng-container>
+  } @else {
+  <button
+    mat-stroked-button
+    type="button"
+    class="add-button"
+    (click)="startAddingBook()"
+  >
+    Add book
+  </button>
+  }
+</section>
+
+<ng-template #bookCard let-book let-variant="variant">
+  @if (isEditing(book)) {
+  <ng-container
+    *ngTemplateOutlet="bookForm; context: { mode: 'edit', book: book }"
+  ></ng-container>
+  } @else {
+  <article
+    class="book"
+    [class.book--completed]="variant === 'completed'"
+    [class.book--wanted]="variant === 'wanted'"
+    [attr.aria-label]="
+      variant === 'completed' ? ariaForBook(book) + ', finished' : ariaForBook(book)
+    "
+  >
+    <header class="book-header">
+      <div class="book-meta">
+        <h4 class="book-title">{{ book.title }}</h4>
+        <p class="book-author">{{ book.author }}</p>
+      </div>
+      <div class="book-actions">
+        <button
+          mat-icon-button
+          type="button"
+          [attr.aria-label]="'Edit ' + book.title"
+          [disabled]="busy()"
+          (click)="startEditingBook(book)"
+        >
+          <mat-icon>edit</mat-icon>
+        </button>
         <button
           mat-icon-button
           type="button"
@@ -23,125 +110,108 @@
           (click)="deleteBook(book)"
         >
           <mat-icon>delete_outline</mat-icon>
-        </button>
-      </header>
-      <p class="book-stats">
-        {{ book.currentPage }} / {{ book.totalPages }} pages
-        @if (averageLabel(book); as label) {
-        <span>· {{ label }}</span>
-        }
-      </p>
-    </article>
-    } @for (book of completedBooks(); track book.id) {
-    <article
-      class="book book--completed"
-      [attr.aria-label]="ariaForBook(book) + ', finished'"
-    >
-      <header class="book-header">
-        <div class="book-meta">
-          <h3 class="book-title">{{ book.title }}</h3>
-          <p class="book-author">{{ book.author }}</p>
-        </div>
-        <button
-          mat-icon-button
-          type="button"
-          [attr.aria-label]="'Remove ' + book.title"
-          [disabled]="busy()"
-          (click)="deleteBook(book)"
-        >
-          <mat-icon>delete_outline</mat-icon>
-        </button>
-      </header>
-      <p class="book-stats">
-        Finished · {{ book.totalPages }} pages
-        @if (averageLabel(book); as label) {
-        <span>· {{ label }}</span>
-        }
-      </p>
-    </article>
-    } @if (addingBook()) {
-    <form
-      class="add-book"
-      aria-labelledby="add-book-heading"
-      (submit)="submitBook(); $event.preventDefault()"
-    >
-      <h3 id="add-book-heading">Add a book</h3>
-      <mat-form-field appearance="outline">
-        <mat-label>Title</mat-label>
-        <input
-          matInput
-          name="title"
-          [ngModel]="draft().title"
-          (ngModelChange)="updateDraft('title', $event)"
-          required
-        />
-      </mat-form-field>
-      <mat-form-field appearance="outline">
-        <mat-label>Author</mat-label>
-        <input
-          matInput
-          name="author"
-          [ngModel]="draft().author"
-          (ngModelChange)="updateDraft('author', $event)"
-          required
-        />
-      </mat-form-field>
-      <mat-form-field appearance="outline">
-        <mat-label>Total pages</mat-label>
-        <input
-          matInput
-          name="totalPages"
-          type="number"
-          min="1"
-          [ngModel]="draft().totalPages"
-          (ngModelChange)="updateDraft('totalPages', $event)"
-          required
-        />
-      </mat-form-field>
-      <mat-form-field appearance="outline">
-        <mat-label>Starting page</mat-label>
-        <input
-          matInput
-          name="startingPage"
-          type="number"
-          min="0"
-          [ngModel]="draft().startingPage"
-          (ngModelChange)="updateDraft('startingPage', $event)"
-        />
-        <mat-hint
-          >Pages already read before tracking. Does not affect reading
-          pace.</mat-hint
-        >
-      </mat-form-field>
-      <div class="actions">
-        <button
-          mat-stroked-button
-          type="button"
-          [disabled]="busy()"
-          (click)="cancelAddingBook()"
-        >
-          Cancel
-        </button>
-        <button
-          mat-flat-button
-          color="primary"
-          type="submit"
-          [disabled]="!canSubmit()"
-        >
-          Add book
         </button>
       </div>
-    </form>
+    </header>
+    @if (variant === 'in-progress') {
+    <p class="book-stats">
+      {{ book.currentPage }} / {{ book.totalPages }} pages
+      @if (averageLabel(book); as label) {
+      <span>· {{ label }}</span>
+      }
+    </p>
+    } @else if (variant === 'completed') {
+    <p class="book-stats">
+      Finished · {{ book.totalPages }} pages
+      @if (averageLabel(book); as label) {
+      <span>· {{ label }}</span>
+      }
+    </p>
     } @else {
-    <button
-      mat-stroked-button
-      type="button"
-      class="add-button"
-      (click)="startAddingBook()"
-    >
-      Add book
-    </button>
+    <p class="book-stats">Page count not set</p>
     }
-  </div>
-</section>
+  </article>
+  }
+</ng-template>
+
+<ng-template #bookForm let-mode="mode">
+  <form
+    class="add-book"
+    [attr.aria-labelledby]="mode === 'edit' ? 'edit-book-heading' : 'add-book-heading'"
+    (submit)="submitBook(); $event.preventDefault()"
+  >
+    @if (mode === 'edit') {
+    <h3 id="edit-book-heading">Edit book</h3>
+    } @else {
+    <h3 id="add-book-heading">Add a book</h3>
+    }
+    <mat-form-field appearance="outline">
+      <mat-label>Title</mat-label>
+      <input
+        matInput
+        name="title"
+        [ngModel]="draft().title"
+        (ngModelChange)="updateDraft('title', $event)"
+        required
+      />
+    </mat-form-field>
+    <mat-form-field appearance="outline">
+      <mat-label>Author</mat-label>
+      <input
+        matInput
+        name="author"
+        [ngModel]="draft().author"
+        (ngModelChange)="updateDraft('author', $event)"
+        required
+      />
+    </mat-form-field>
+    <mat-form-field appearance="outline">
+      <mat-label>Total pages</mat-label>
+      <input
+        matInput
+        name="totalPages"
+        type="number"
+        min="1"
+        [ngModel]="draft().totalPages"
+        (ngModelChange)="updateDraft('totalPages', $event)"
+      />
+      <mat-hint>Leave empty to add to your wanted list.</mat-hint>
+    </mat-form-field>
+    @if (draft().totalPages !== null) {
+    <mat-form-field appearance="outline">
+      <mat-label>Starting page</mat-label>
+      <input
+        matInput
+        name="startingPage"
+        type="number"
+        min="0"
+        [ngModel]="draft().startingPage"
+        (ngModelChange)="updateDraft('startingPage', $event)"
+      />
+      <mat-hint
+        >Pages already read before tracking. Does not affect reading
+        pace.</mat-hint
+      >
+    </mat-form-field>
+    }
+    <div class="actions">
+      <button
+        mat-stroked-button
+        type="button"
+        [disabled]="busy()"
+        (click)="mode === 'edit' ? cancelEditingBook() : cancelAddingBook()"
+      >
+        Cancel
+      </button>
+      <button
+        mat-flat-button
+        color="primary"
+        type="submit"
+        [disabled]="!canSubmit()"
+      >
+        {{ mode === 'edit' ? 'Save book' : 'Add book' }}
+      </button>
+    </div>
+  </form>
+</ng-template>
 }

--- a/client/src/app/reading/reading-library.component.html
+++ b/client/src/app/reading/reading-library.component.html
@@ -74,9 +74,9 @@
 </section>
 
 <ng-template #bookCard let-book let-variant="variant">
-  @if (isEditing(book)) {
+  @if (editingBookId() === book.id) {
   <ng-container
-    *ngTemplateOutlet="bookForm; context: { mode: 'edit', book: book }"
+    *ngTemplateOutlet="bookForm; context: { mode: 'edit' }"
   ></ng-container>
   } @else {
   <article
@@ -199,7 +199,7 @@
         mat-stroked-button
         type="button"
         [disabled]="busy()"
-        (click)="mode === 'edit' ? cancelEditingBook() : cancelAddingBook()"
+        (click)="cancelForm()"
       >
         Cancel
       </button>

--- a/client/src/app/reading/reading-library.component.ts
+++ b/client/src/app/reading/reading-library.component.ts
@@ -1,3 +1,4 @@
+import { NgTemplateOutlet } from '@angular/common';
 import { Component, computed, inject, resource, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
@@ -7,16 +8,24 @@ import { MatInputModule } from '@angular/material/input';
 import { BarLoaderComponent } from '@mucsi96/angular-material-theme';
 import { Book, ReadingService } from './reading.service';
 
-type NewBookDraft = {
+type BookDraft = {
   title: string;
   author: string;
   totalPages: number | null;
   startingPage: number | null;
 };
 
+const emptyDraft = (): BookDraft => ({
+  title: '',
+  author: '',
+  totalPages: null,
+  startingPage: null,
+});
+
 @Component({
   standalone: true,
   imports: [
+    NgTemplateOutlet,
     FormsModule,
     MatButtonModule,
     MatFormFieldModule,
@@ -33,12 +42,8 @@ export class ReadingLibraryComponent {
 
   readonly busy = signal(false);
   readonly addingBook = signal(false);
-  readonly draft = signal<NewBookDraft>({
-    title: '',
-    author: '',
-    totalPages: null,
-    startingPage: null,
-  });
+  readonly editingBookId = signal<string | null>(null);
+  readonly draft = signal<BookDraft>(emptyDraft());
 
   readonly books = resource({
     params: () => this.readingService.version(),
@@ -46,28 +51,35 @@ export class ReadingLibraryComponent {
   });
 
   readonly inProgressBooks = computed(
-    () => this.books.value()?.filter((book) => !book.completedAt) ?? []
+    () =>
+      this.books.value()?.filter(
+        (book) => book.totalPages !== null && !book.completedAt
+      ) ?? []
   );
   readonly completedBooks = computed(
-    () => this.books.value()?.filter((book) => book.completedAt) ?? []
+    () => this.books.value()?.filter((book) => !!book.completedAt) ?? []
+  );
+  readonly wantedBooks = computed(
+    () => this.books.value()?.filter((book) => book.totalPages === null) ?? []
   );
 
   readonly canSubmit = computed(() => {
     const d = this.draft();
+    if (this.busy()) return false;
+    if (d.title.trim().length === 0 || d.author.trim().length === 0) {
+      return false;
+    }
+    if (d.totalPages === null) {
+      return (d.startingPage ?? 0) === 0;
+    }
+    if (d.totalPages <= 0) return false;
     const startingPage = d.startingPage ?? 0;
-    return (
-      !this.busy() &&
-      d.title.trim().length > 0 &&
-      d.author.trim().length > 0 &&
-      typeof d.totalPages === 'number' &&
-      d.totalPages > 0 &&
-      startingPage >= 0 &&
-      startingPage < d.totalPages
-    );
+    return startingPage >= 0 && startingPage < d.totalPages;
   });
 
   startAddingBook() {
-    this.draft.set({ title: '', author: '', totalPages: null, startingPage: null });
+    this.editingBookId.set(null);
+    this.draft.set(emptyDraft());
     this.addingBook.set(true);
   }
 
@@ -75,22 +87,49 @@ export class ReadingLibraryComponent {
     this.addingBook.set(false);
   }
 
-  updateDraft<K extends keyof NewBookDraft>(field: K, value: NewBookDraft[K]) {
+  startEditingBook(book: Book) {
+    this.addingBook.set(false);
+    this.draft.set({
+      title: book.title,
+      author: book.author,
+      totalPages: book.totalPages,
+      startingPage: book.startingPage,
+    });
+    this.editingBookId.set(book.id);
+  }
+
+  cancelEditingBook() {
+    this.editingBookId.set(null);
+  }
+
+  updateDraft<K extends keyof BookDraft>(field: K, value: BookDraft[K]) {
     this.draft.update((d) => ({ ...d, [field]: value }));
   }
 
   async submitBook() {
     if (!this.canSubmit()) return;
     const d = this.draft();
+    const editingId = this.editingBookId();
     this.busy.set(true);
     try {
-      await this.readingService.addBook(
-        d.title.trim(),
-        d.author.trim(),
-        d.totalPages as number,
-        d.startingPage ?? 0
-      );
-      this.addingBook.set(false);
+      if (editingId) {
+        await this.readingService.updateBook(
+          editingId,
+          d.title.trim(),
+          d.author.trim(),
+          d.totalPages,
+          d.startingPage ?? 0
+        );
+        this.editingBookId.set(null);
+      } else {
+        await this.readingService.addBook(
+          d.title.trim(),
+          d.author.trim(),
+          d.totalPages,
+          d.startingPage ?? 0
+        );
+        this.addingBook.set(false);
+      }
     } finally {
       this.busy.set(false);
     }
@@ -107,6 +146,9 @@ export class ReadingLibraryComponent {
   }
 
   ariaForBook(book: Book): string {
+    if (book.totalPages === null) {
+      return `${book.title}, wanted`;
+    }
     return `${book.title}, ${book.currentPage} of ${book.totalPages} pages`;
   }
 
@@ -115,5 +157,9 @@ export class ReadingLibraryComponent {
       return null;
     }
     return `${book.averagePagesPerDay.toFixed(1)} pages/day avg`;
+  }
+
+  isEditing(book: Book): boolean {
+    return this.editingBookId() === book.id;
   }
 }

--- a/client/src/app/reading/reading-library.component.ts
+++ b/client/src/app/reading/reading-library.component.ts
@@ -83,10 +83,6 @@ export class ReadingLibraryComponent {
     this.addingBook.set(true);
   }
 
-  cancelAddingBook() {
-    this.addingBook.set(false);
-  }
-
   startEditingBook(book: Book) {
     this.addingBook.set(false);
     this.draft.set({
@@ -98,8 +94,12 @@ export class ReadingLibraryComponent {
     this.editingBookId.set(book.id);
   }
 
-  cancelEditingBook() {
-    this.editingBookId.set(null);
+  cancelForm() {
+    if (this.editingBookId() !== null) {
+      this.editingBookId.set(null);
+    } else {
+      this.addingBook.set(false);
+    }
   }
 
   updateDraft<K extends keyof BookDraft>(field: K, value: BookDraft[K]) {
@@ -157,9 +157,5 @@ export class ReadingLibraryComponent {
       return null;
     }
     return `${book.averagePagesPerDay.toFixed(1)} pages/day avg`;
-  }
-
-  isEditing(book: Book): boolean {
-    return this.editingBookId() === book.id;
   }
 }

--- a/client/src/app/reading/reading-library.component.ts
+++ b/client/src/app/reading/reading-library.component.ts
@@ -103,7 +103,13 @@ export class ReadingLibraryComponent {
   }
 
   updateDraft<K extends keyof BookDraft>(field: K, value: BookDraft[K]) {
-    this.draft.update((d) => ({ ...d, [field]: value }));
+    this.draft.update((d) => {
+      const next = { ...d, [field]: value };
+      if (field === 'totalPages' && value === null) {
+        next.startingPage = null;
+      }
+      return next;
+    });
   }
 
   async submitBook() {

--- a/client/src/app/reading/reading-progress-dialog.component.html
+++ b/client/src/app/reading/reading-progress-dialog.component.html
@@ -5,7 +5,7 @@
     class="slider"
     [(value)]="page"
     [min]="book.startingPage"
-    [max]="book.totalPages"
+    [max]="totalPages"
     [valuePerTurn]="10"
     label="Page"
     [unit]="pageUnit"

--- a/client/src/app/reading/reading-progress-dialog.component.ts
+++ b/client/src/app/reading/reading-progress-dialog.component.ts
@@ -35,9 +35,10 @@ export class ReadingProgressDialogComponent {
   readonly data = inject<ReadingProgressDialogData>(MAT_DIALOG_DATA);
 
   readonly book = this.data.book;
+  readonly totalPages = this.book.totalPages ?? 0;
   readonly page = signal(this.book.currentPage);
   readonly canSave = computed(() => this.page() !== this.book.currentPage);
-  readonly pageUnit = `/ ${this.book.totalPages}`;
+  readonly pageUnit = `/ ${this.totalPages}`;
 
   cancel(): void {
     this.dialogRef.close(null);

--- a/client/src/app/reading/reading.component.ts
+++ b/client/src/app/reading/reading.component.ts
@@ -27,11 +27,14 @@ export class ReadingComponent {
   });
 
   readonly inProgressBooks = computed(
-    () => this.books.value()?.filter((book) => !book.completedAt) ?? []
+    () =>
+      this.books.value()?.filter(
+        (book) => book.totalPages !== null && !book.completedAt
+      ) ?? []
   );
 
   bookProgressPercent(book: Book): number {
-    return book.totalPages > 0
+    return book.totalPages && book.totalPages > 0
       ? Math.min(100, (book.currentPage / book.totalPages) * 100)
       : 0;
   }

--- a/client/src/app/reading/reading.service.ts
+++ b/client/src/app/reading/reading.service.ts
@@ -7,7 +7,7 @@ export type Book = {
   id: string;
   title: string;
   author: string;
-  totalPages: number;
+  totalPages: number | null;
   startingPage: number;
   currentPage: number;
   createdAt: Date;
@@ -21,7 +21,7 @@ type BookDto = {
   id: string;
   title: string;
   author: string;
-  totalPages: number;
+  totalPages?: number | null;
   startingPage: number;
   currentPage: number;
   createdAt: string;
@@ -33,6 +33,7 @@ type BookDto = {
 
 const toBook = (dto: BookDto): Book => ({
   ...dto,
+  totalPages: dto.totalPages ?? null,
   createdAt: new Date(dto.createdAt),
   startedAt: dto.startedAt ? new Date(dto.startedAt) : undefined,
   completedAt: dto.completedAt ? new Date(dto.completedAt) : undefined,
@@ -57,7 +58,7 @@ export class ReadingService {
   async addBook(
     title: string,
     author: string,
-    totalPages: number,
+    totalPages: number | null,
     startingPage: number
   ): Promise<Book> {
     try {
@@ -69,6 +70,27 @@ export class ReadingService {
       return toBook(book);
     } catch (e) {
       this.notifications.error('Unable to add book');
+      throw e;
+    }
+  }
+
+  async updateBook(
+    bookId: string,
+    title: string,
+    author: string,
+    totalPages: number | null,
+    startingPage: number
+  ): Promise<Book> {
+    try {
+      const book = await fetchJson<BookDto>(
+        this.http,
+        `/api/reading/books/${bookId}`,
+        { method: 'put', body: { title, author, totalPages, startingPage } }
+      );
+      this.version.update((v) => v + 1);
+      return toBook(book);
+    } catch (e) {
+      this.notifications.error('Unable to update book');
       throw e;
     }
   }

--- a/server/src/main/java/mucsi96/traininglog/reading/BookEntity.java
+++ b/server/src/main/java/mucsi96/traininglog/reading/BookEntity.java
@@ -28,8 +28,8 @@ public class BookEntity {
   @Column(nullable = false)
   private String author;
 
-  @Column(name = "total_pages", nullable = false)
-  private int totalPages;
+  @Column(name = "total_pages")
+  private Integer totalPages;
 
   @Column(name = "starting_page", nullable = false)
   private int startingPage;

--- a/server/src/main/java/mucsi96/traininglog/reading/ReadingController.java
+++ b/server/src/main/java/mucsi96/traininglog/reading/ReadingController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -45,11 +46,23 @@ public class ReadingController {
 
   @PostMapping(value = "/books", consumes = MediaType.APPLICATION_JSON_VALUE)
   @PreAuthorize("hasAuthority('APPROLE_WorkoutCreator') and hasAuthority('SCOPE_createWorkout')")
-  Book addBook(@Valid @RequestBody AddBookRequest request, @RequestHeader("X-Timezone") ZoneId zoneId) {
+  Book addBook(@Valid @RequestBody BookRequest request, @RequestHeader("X-Timezone") ZoneId zoneId) {
     int startingPage = request.getStartingPage() == null ? 0 : request.getStartingPage();
     BookSummary saved = readingService.addBook(
         request.getTitle().trim(), request.getAuthor().trim(), request.getTotalPages(), startingPage);
     return toResponse(saved, zoneId);
+  }
+
+  @PutMapping(value = "/books/{id}", consumes = MediaType.APPLICATION_JSON_VALUE)
+  @PreAuthorize("hasAuthority('APPROLE_WorkoutCreator') and hasAuthority('SCOPE_createWorkout')")
+  Book updateBook(
+      @PathVariable UUID id,
+      @Valid @RequestBody BookRequest request,
+      @RequestHeader("X-Timezone") ZoneId zoneId) {
+    int startingPage = request.getStartingPage() == null ? 0 : request.getStartingPage();
+    BookSummary updated = readingService.updateBook(
+        id, request.getTitle().trim(), request.getAuthor().trim(), request.getTotalPages(), startingPage);
+    return toResponse(updated, zoneId);
   }
 
   @PostMapping(value = "/books/{id}/progress", consumes = MediaType.APPLICATION_JSON_VALUE)
@@ -101,14 +114,13 @@ public class ReadingController {
   }
 
   @Data
-  public static class AddBookRequest {
+  public static class BookRequest {
     @NotBlank
     @Size(max = 255)
     private String title;
     @NotBlank
     @Size(max = 255)
     private String author;
-    @NotNull
     @Min(1)
     @Max(100000)
     private Integer totalPages;

--- a/server/src/main/java/mucsi96/traininglog/reading/ReadingProgressRepository.java
+++ b/server/src/main/java/mucsi96/traininglog/reading/ReadingProgressRepository.java
@@ -1,7 +1,6 @@
 package mucsi96.traininglog.reading;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.domain.Sort;
@@ -11,8 +10,6 @@ public interface ReadingProgressRepository extends JpaRepository<ReadingProgress
   List<ReadingProgressEntity> findAll(Sort sort);
 
   List<ReadingProgressEntity> findByBookId(UUID bookId, Sort sort);
-
-  Optional<ReadingProgressEntity> findTopByBookIdOrderByCreatedAtDesc(UUID bookId);
 
   void deleteByBookId(UUID bookId);
 }

--- a/server/src/main/java/mucsi96/traininglog/reading/ReadingProgressRepository.java
+++ b/server/src/main/java/mucsi96/traininglog/reading/ReadingProgressRepository.java
@@ -1,6 +1,7 @@
 package mucsi96.traininglog.reading;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.springframework.data.domain.Sort;
@@ -10,6 +11,8 @@ public interface ReadingProgressRepository extends JpaRepository<ReadingProgress
   List<ReadingProgressEntity> findAll(Sort sort);
 
   List<ReadingProgressEntity> findByBookId(UUID bookId, Sort sort);
+
+  Optional<ReadingProgressEntity> findTopByBookIdOrderByCreatedAtDesc(UUID bookId);
 
   void deleteByBookId(UUID bookId);
 }

--- a/server/src/main/java/mucsi96/traininglog/reading/ReadingService.java
+++ b/server/src/main/java/mucsi96/traininglog/reading/ReadingService.java
@@ -57,12 +57,13 @@ public class ReadingService {
     BookEntity book = bookRepository.findById(bookId)
         .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Book not found"));
     validatePages(totalPages, startingPage);
-    List<ReadingProgressEntity> progress = progressRepository
-        .findByBookId(bookId, Sort.by(Sort.Direction.ASC, "createdAt"));
-    int currentPage = progress.stream()
-        .max(Comparator.comparing(ReadingProgressEntity::getCreatedAt))
+    int currentPage = progressRepository.findTopByBookIdOrderByCreatedAtDesc(bookId)
         .map(ReadingProgressEntity::getCurrentPage)
         .orElse(startingPage);
+    if (currentPage < startingPage) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+          "startingPage cannot be greater than the latest recorded page " + currentPage);
+    }
     if (totalPages != null && currentPage > totalPages) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
           "totalPages cannot be less than the latest recorded page " + currentPage);
@@ -78,6 +79,8 @@ public class ReadingService {
     } else if (currentPage < totalPages && book.getCompletedAt() != null) {
       book.setCompletedAt(null);
     }
+    List<ReadingProgressEntity> progress = progressRepository
+        .findByBookId(bookId, Sort.by(Sort.Direction.ASC, "createdAt"));
     return toSummary(bookRepository.save(book), progress);
   }
 

--- a/server/src/main/java/mucsi96/traininglog/reading/ReadingService.java
+++ b/server/src/main/java/mucsi96/traininglog/reading/ReadingService.java
@@ -37,11 +37,8 @@ public class ReadingService {
   private final Clock clock;
 
   @Transactional
-  public BookSummary addBook(String title, String author, int totalPages, int startingPage) {
-    if (startingPage < 0 || startingPage >= totalPages) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
-          "startingPage must be between 0 and " + (totalPages - 1));
-    }
+  public BookSummary addBook(String title, String author, Integer totalPages, int startingPage) {
+    validatePages(totalPages, startingPage);
     BookEntity book = BookEntity.builder()
         .id(UUID.randomUUID())
         .title(title)
@@ -56,9 +53,42 @@ public class ReadingService {
   }
 
   @Transactional
+  public BookSummary updateBook(UUID bookId, String title, String author, Integer totalPages, int startingPage) {
+    BookEntity book = bookRepository.findById(bookId)
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Book not found"));
+    validatePages(totalPages, startingPage);
+    List<ReadingProgressEntity> progress = progressRepository
+        .findByBookId(bookId, Sort.by(Sort.Direction.ASC, "createdAt"));
+    int currentPage = progress.stream()
+        .max(Comparator.comparing(ReadingProgressEntity::getCreatedAt))
+        .map(ReadingProgressEntity::getCurrentPage)
+        .orElse(startingPage);
+    if (totalPages != null && currentPage > totalPages) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+          "totalPages cannot be less than the latest recorded page " + currentPage);
+    }
+    book.setTitle(title);
+    book.setAuthor(author);
+    book.setTotalPages(totalPages);
+    book.setStartingPage(startingPage);
+    if (totalPages == null) {
+      book.setCompletedAt(null);
+    } else if (currentPage >= totalPages && book.getCompletedAt() == null) {
+      book.setCompletedAt(now());
+    } else if (currentPage < totalPages && book.getCompletedAt() != null) {
+      book.setCompletedAt(null);
+    }
+    return toSummary(bookRepository.save(book), progress);
+  }
+
+  @Transactional
   public BookSummary updateProgress(UUID bookId, int currentPage) {
     BookEntity book = bookRepository.findById(bookId)
         .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Book not found"));
+    if (book.getTotalPages() == null) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+          "Cannot record progress on a wanted book without a page count");
+    }
     if (currentPage < book.getStartingPage() || currentPage > book.getTotalPages()) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
           "currentPage must be between " + book.getStartingPage() + " and " + book.getTotalPages());
@@ -137,6 +167,20 @@ public class ReadingService {
     return ZonedDateTime.now(clock).withZoneSameInstant(ZoneOffset.UTC).truncatedTo(ChronoUnit.MILLIS);
   }
 
+  private void validatePages(Integer totalPages, int startingPage) {
+    if (totalPages == null) {
+      if (startingPage != 0) {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+            "startingPage must be 0 when totalPages is not provided");
+      }
+      return;
+    }
+    if (startingPage < 0 || startingPage >= totalPages) {
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+          "startingPage must be between 0 and " + (totalPages - 1));
+    }
+  }
+
   private BookSummary toSummary(BookEntity book, List<ReadingProgressEntity> progress) {
     Optional<ReadingProgressEntity> latest = progress.stream()
         .max(Comparator.comparing(ReadingProgressEntity::getCreatedAt));
@@ -149,7 +193,7 @@ public class ReadingService {
     Double averagePagesPerDay = null;
     Integer estimatedDaysRemaining = null;
     int pagesReadSinceStart = currentPage - book.getStartingPage();
-    if (startedAt.isPresent() && pagesReadSinceStart > 0) {
+    if (book.getTotalPages() != null && startedAt.isPresent() && pagesReadSinceStart > 0) {
       long daysElapsed = Math.max(1,
           ChronoUnit.DAYS.between(startedAt.get().toLocalDate(), now().toLocalDate()) + 1);
       double avg = (double) pagesReadSinceStart / daysElapsed;
@@ -183,7 +227,7 @@ public class ReadingService {
     private UUID id;
     private String title;
     private String author;
-    private int totalPages;
+    private Integer totalPages;
     private int startingPage;
     private int currentPage;
     private ZonedDateTime createdAt;

--- a/server/src/main/java/mucsi96/traininglog/reading/ReadingService.java
+++ b/server/src/main/java/mucsi96/traininglog/reading/ReadingService.java
@@ -57,9 +57,11 @@ public class ReadingService {
     BookEntity book = bookRepository.findById(bookId)
         .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Book not found"));
     validatePages(totalPages, startingPage);
-    int currentPage = progressRepository.findTopByBookIdOrderByCreatedAtDesc(bookId)
-        .map(ReadingProgressEntity::getCurrentPage)
-        .orElse(startingPage);
+    List<ReadingProgressEntity> progress = progressRepository
+        .findByBookId(bookId, Sort.by(Sort.Direction.ASC, "createdAt"));
+    int currentPage = progress.isEmpty()
+        ? startingPage
+        : progress.get(progress.size() - 1).getCurrentPage();
     if (currentPage < startingPage) {
       throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
           "startingPage cannot be greater than the latest recorded page " + currentPage);
@@ -79,8 +81,6 @@ public class ReadingService {
     } else if (currentPage < totalPages && book.getCompletedAt() != null) {
       book.setCompletedAt(null);
     }
-    List<ReadingProgressEntity> progress = progressRepository
-        .findByBookId(bookId, Sort.by(Sort.Direction.ASC, "createdAt"));
     return toSummary(bookRepository.save(book), progress);
   }
 

--- a/server/src/main/resources/api.yml
+++ b/server/src/main/resources/api.yml
@@ -313,7 +313,6 @@ paths:
               required:
                 - title
                 - author
-                - totalPages
               properties:
                 title:
                   type: string
@@ -377,6 +376,40 @@ paths:
         schema:
           type: string
           format: uuid
+    put:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - title
+                - author
+              properties:
+                title:
+                  type: string
+                  minLength: 1
+                  maxLength: 255
+                author:
+                  type: string
+                  minLength: 1
+                  maxLength: 255
+                totalPages:
+                  type: integer
+                  minimum: 1
+                  maximum: 100000
+                startingPage:
+                  type: integer
+                  minimum: 0
+                  maximum: 100000
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Book'
     delete:
       responses:
         '204':
@@ -465,7 +498,6 @@ components:
         - id
         - title
         - author
-        - totalPages
         - startingPage
         - currentPage
         - createdAt

--- a/server/src/main/resources/api.yml
+++ b/server/src/main/resources/api.yml
@@ -410,6 +410,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Book'
+        '400':
+          description: Invalid request, e.g. startingPage or totalPages out of range
+        '404':
+          description: Book not found
     delete:
       responses:
         '204':

--- a/server/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/server/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -582,3 +582,12 @@ databaseChangeLog:
                   type: float4
                   constraints:
                     nullable: true
+
+  - changeSet:
+      id: 22-make-book-total-pages-nullable
+      author: mucsi96
+      changes:
+        - dropNotNullConstraint:
+            tableName: book
+            columnName: total_pages
+            columnDataType: integer

--- a/test/tests/reading.spec.ts
+++ b/test/tests/reading.spec.ts
@@ -442,6 +442,36 @@ test.describe('Reading', () => {
     expect(books[0].total_pages).toBe(300);
   });
 
+  test('moves a book to the wanted list when its page count is cleared', async ({
+    page,
+  }) => {
+    const bookId = randomUUID();
+    await insertBook(bookId, 'On The Fence', 'Author', 200, daysAgoAt(1, 8));
+
+    await page.goto('/settings');
+    const library = page.getByRole('region', { name: 'Books' });
+    await library.getByRole('button', { name: 'Edit On The Fence' }).click();
+    await library.getByLabel('Total pages').fill('');
+    await library.getByRole('button', { name: 'Save book' }).click();
+
+    await expect(
+      library.getByRole('heading', { name: 'Wanted list' })
+    ).toBeVisible();
+    await expect(
+      library.getByRole('heading', { name: 'Reading in progress' })
+    ).toBeHidden();
+
+    const books = await getBookRows();
+    expect(books[0].total_pages).toBeNull();
+    expect(books[0].starting_page).toBe(0);
+
+    await page.goto('/');
+    const section = page.getByRole('region', { name: 'Reading' });
+    await expect(
+      section.getByRole('heading', { name: 'On The Fence' })
+    ).toBeHidden();
+  });
+
   test('moves a wanted book to reading in progress when a page count is added', async ({
     page,
   }) => {

--- a/test/tests/reading.spec.ts
+++ b/test/tests/reading.spec.ts
@@ -316,6 +316,98 @@ test.describe('Reading', () => {
     ).toBeVisible();
   });
 
+  test('adds a wanted book without a page count and hides it from the dashboard', async ({
+    page,
+  }) => {
+    await page.goto('/settings');
+    const library = page.getByRole('region', { name: 'Books' });
+
+    await library.getByRole('button', { name: 'Add book' }).click();
+    await library.getByLabel('Title').fill('Some Day');
+    await library.getByLabel('Author').fill('Future Author');
+    await library.getByRole('button', { name: 'Add book' }).click();
+
+    await expect(
+      library.getByRole('heading', { name: 'Wanted list' })
+    ).toBeVisible();
+    await expect(
+      library.getByRole('heading', { name: 'Some Day' })
+    ).toBeVisible();
+    await expect(library.getByText('Page count not set')).toBeVisible();
+
+    const books = await getBookRows();
+    expect(books).toHaveLength(1);
+    expect(books[0].total_pages).toBeNull();
+    expect(books[0].starting_page).toBe(0);
+
+    await page.goto('/');
+    const section = page.getByRole('region', { name: 'Reading' });
+    await expect(
+      section.getByRole('heading', { name: 'Some Day' })
+    ).toBeHidden();
+    await expect(
+      section.getByText('No books in progress. Add a book in Settings.')
+    ).toBeVisible();
+  });
+
+  test('edits an existing book through the settings page', async ({ page }) => {
+    const bookId = randomUUID();
+    await insertBook(bookId, 'Old Title', 'Old Author', 200, daysAgoAt(1, 8));
+
+    await page.goto('/settings');
+    const library = page.getByRole('region', { name: 'Books' });
+    await library.getByRole('button', { name: 'Edit Old Title' }).click();
+
+    await library.getByLabel('Title').fill('New Title');
+    await library.getByLabel('Author').fill('New Author');
+    await library.getByLabel('Total pages').fill('250');
+    await library.getByRole('button', { name: 'Save book' }).click();
+
+    await expect(
+      library.getByRole('heading', { name: 'New Title' })
+    ).toBeVisible();
+    await expect(library.getByText('New Author')).toBeVisible();
+
+    const books = await getBookRows();
+    expect(books).toHaveLength(1);
+    expect(books[0].title).toBe('New Title');
+    expect(books[0].author).toBe('New Author');
+    expect(books[0].total_pages).toBe(250);
+  });
+
+  test('moves a wanted book to reading in progress when a page count is added', async ({
+    page,
+  }) => {
+    const bookId = randomUUID();
+    await insertBook(bookId, 'Wanted Book', 'Author', null, daysAgoAt(1, 8));
+
+    await page.goto('/settings');
+    const library = page.getByRole('region', { name: 'Books' });
+
+    await expect(
+      library.getByRole('heading', { name: 'Wanted list' })
+    ).toBeVisible();
+    await library.getByRole('button', { name: 'Edit Wanted Book' }).click();
+    await library.getByLabel('Total pages').fill('180');
+    await library.getByRole('button', { name: 'Save book' }).click();
+
+    await expect(
+      library.getByRole('heading', { name: 'Wanted list' })
+    ).toBeHidden();
+    await expect(
+      library.getByRole('heading', { name: 'Reading in progress' })
+    ).toBeVisible();
+
+    const books = await getBookRows();
+    expect(books[0].total_pages).toBe(180);
+
+    await page.goto('/');
+    const section = page.getByRole('region', { name: 'Reading' });
+    await expect(
+      section.getByRole('button', { name: /Wanted Book, 0 of 180 pages/ })
+    ).toBeVisible();
+  });
+
   test('reflects the configured daily reading goal', async ({ page }) => {
     await setGoals(100, 250, 50);
     const bookId = randomUUID();

--- a/test/tests/reading.spec.ts
+++ b/test/tests/reading.spec.ts
@@ -375,6 +375,73 @@ test.describe('Reading', () => {
     expect(books[0].total_pages).toBe(250);
   });
 
+  test('restores the book card when an edit is cancelled', async ({ page }) => {
+    const bookId = randomUUID();
+    await insertBook(bookId, 'Keep Me', 'Author', 200, daysAgoAt(1, 8));
+
+    await page.goto('/settings');
+    const library = page.getByRole('region', { name: 'Books' });
+    await library.getByRole('button', { name: 'Edit Keep Me' }).click();
+
+    await expect(
+      library.getByRole('heading', { name: 'Edit book' })
+    ).toBeVisible();
+    await library.getByLabel('Title').fill('Different Title');
+    await library.getByRole('button', { name: 'Cancel' }).click();
+
+    await expect(
+      library.getByRole('heading', { name: 'Edit book' })
+    ).toBeHidden();
+    await expect(
+      library.getByRole('heading', { name: 'Keep Me' })
+    ).toBeVisible();
+    await expect(
+      library.getByRole('heading', { name: 'Different Title' })
+    ).toBeHidden();
+
+    const books = await getBookRows();
+    expect(books).toHaveLength(1);
+    expect(books[0].title).toBe('Keep Me');
+  });
+
+  test('rejects an edit that sets the starting page above the current page', async ({
+    page,
+  }) => {
+    const bookId = randomUUID();
+    await insertBook(bookId, 'Halfway Book', 'Author', 300, daysAgoAt(2, 8));
+    await insertReadingProgress(bookId, 50, daysAgoAt(0, 12));
+
+    await page.goto('/settings');
+    const library = page.getByRole('region', { name: 'Books' });
+    await library.getByRole('button', { name: 'Edit Halfway Book' }).click();
+    await library.getByLabel('Starting page').fill('150');
+    await library.getByRole('button', { name: 'Save book' }).click();
+
+    await expect(page.getByText('Unable to update book')).toBeVisible();
+
+    const books = await getBookRows();
+    expect(books[0].starting_page).toBe(0);
+  });
+
+  test('rejects an edit that lowers total pages below the current page', async ({
+    page,
+  }) => {
+    const bookId = randomUUID();
+    await insertBook(bookId, 'Too Far In', 'Author', 300, daysAgoAt(2, 8));
+    await insertReadingProgress(bookId, 150, daysAgoAt(0, 12));
+
+    await page.goto('/settings');
+    const library = page.getByRole('region', { name: 'Books' });
+    await library.getByRole('button', { name: 'Edit Too Far In' }).click();
+    await library.getByLabel('Total pages').fill('100');
+    await library.getByRole('button', { name: 'Save book' }).click();
+
+    await expect(page.getByText('Unable to update book')).toBeVisible();
+
+    const books = await getBookRows();
+    expect(books[0].total_pages).toBe(300);
+  });
+
   test('moves a wanted book to reading in progress when a page count is added', async ({
     page,
   }) => {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -238,7 +238,7 @@ export async function insertBook(
   id: string,
   title: string,
   author: string,
-  totalPages: number,
+  totalPages: number | null,
   createdAt: Date = new Date(),
   completedAt: Date | null = null,
   startingPage: number = 0


### PR DESCRIPTION
## Summary
This PR adds support for a "wanted list" of books without page counts and enables editing existing books. Books can now be added to a wanted list by omitting the total pages field, and users can edit any book's details through the settings page.

## Key Changes

### Frontend
- **Refactored book display**: Extracted book card rendering into a reusable `#bookCard` template to reduce duplication across in-progress, completed, and wanted books
- **Added wanted books support**: Books without a page count are now displayed in a separate "Wanted list" section with distinct styling (dashed border, reduced opacity)
- **Implemented book editing**: Added `startEditingBook()` and `cancelEditingBook()` methods with an `editingBookId` signal to track which book is being edited
- **Unified form handling**: Converted the add book form into a reusable `#bookForm` template that handles both add and edit modes
- **Updated validation**: Modified `canSubmit()` to allow books without page counts (for wanted list) while validating that starting page is 0 when total pages is null
- **Organized book sections**: Books are now grouped by status (Reading in progress, Already read, Wanted list) with section headings
- **Updated aria labels**: Enhanced accessibility labels to indicate book status (e.g., "finished" for completed books, "wanted" for wanted books)

### Backend
- **Made totalPages nullable**: Changed `Book.totalPages` from required `int` to nullable `Integer` in both entity and API
- **Added updateBook endpoint**: Implemented `PUT /api/reading/books/{id}` to support editing book details
- **Enhanced validation**: Created `validatePages()` method to handle validation for both nullable and non-nullable page counts
- **Prevented progress on wanted books**: Added check to prevent recording reading progress on books without a page count
- **Auto-complete logic**: When editing a book, if current page >= total pages, the book is automatically marked as completed
- **Database migration**: Added changelog to make `total_pages` column nullable

### Service Layer
- **Updated ReadingService**: Modified `addBook()` to accept nullable `totalPages` and added new `updateBook()` method
- **Updated ReadingService client**: Added `updateBook()` method to support editing books via API

### Testing
- Added test for adding a wanted book without page count and verifying it's hidden from dashboard
- Added test for editing an existing book through settings
- Added test for converting a wanted book to in-progress by adding a page count

## Notable Implementation Details
- The book form template uses conditional rendering to show/hide the starting page field only when total pages is set
- Edit mode reuses the same form template as add mode, with conditional button labels and heading text
- The wanted books list is only shown when there are books without page counts
- Wanted books have distinct visual styling to differentiate them from books in progress

https://claude.ai/code/session_013iJrijVt5fAKzmmtChZeR6