### PR TITLE
Add copy button to books in settings

### DIFF
--- a/client/src/app/reading/reading-library.component.html
+++ b/client/src/app/reading/reading-library.component.html
@@ -96,6 +96,14 @@
         <button
           mat-icon-button
           type="button"
+          [attr.aria-label]="'Copy ' + book.title"
+          (click)="copyBook(book)"
+        >
+          <mat-icon>content_copy</mat-icon>
+        </button>
+        <button
+          mat-icon-button
+          type="button"
           [attr.aria-label]="'Edit ' + book.title"
           [disabled]="busy()"
           (click)="startEditingBook(book)"

--- a/client/src/app/reading/reading-library.component.ts
+++ b/client/src/app/reading/reading-library.component.ts
@@ -5,7 +5,10 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
-import { BarLoaderComponent } from '@mucsi96/angular-material-theme';
+import {
+  BarLoaderComponent,
+  NotificationsService,
+} from '@mucsi96/angular-material-theme';
 import { Book, ReadingService } from './reading.service';
 
 type BookDraft = {
@@ -39,6 +42,7 @@ const emptyDraft = (): BookDraft => ({
 })
 export class ReadingLibraryComponent {
   private readonly readingService = inject(ReadingService);
+  private readonly notifications = inject(NotificationsService);
 
   readonly busy = signal(false);
   readonly addingBook = signal(false);
@@ -138,6 +142,16 @@ export class ReadingLibraryComponent {
       }
     } finally {
       this.busy.set(false);
+    }
+  }
+
+  async copyBook(book: Book) {
+    const text = `${book.author} - ${book.title}`;
+    try {
+      await navigator.clipboard.writeText(text);
+      this.notifications.success('Copied to clipboard');
+    } catch {
+      this.notifications.error('Unable to copy to clipboard');
     }
   }
 

--- a/test/tests/reading.spec.ts
+++ b/test/tests/reading.spec.ts
@@ -286,6 +286,26 @@ test.describe('Reading', () => {
     expect(await getReadingProgressRows()).toHaveLength(0);
   });
 
+  test('copies author and title to the clipboard from the settings page', async ({
+    page,
+    context,
+  }) => {
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+    const bookId = randomUUID();
+    await insertBook(bookId, 'Deep Work', 'Cal Newport', 300, daysAgoAt(1, 8));
+
+    await page.goto('/settings');
+    const library = page.getByRole('region', { name: 'Books' });
+    await library.getByRole('button', { name: 'Copy Deep Work' }).click();
+
+    await expect(page.getByText('Copied to clipboard')).toBeVisible();
+
+    const clipboardText = await page.evaluate(() =>
+      navigator.clipboard.readText()
+    );
+    expect(clipboardText).toBe('Cal Newport - Deep Work');
+  });
+
   test('shows finished books only on the settings page', async ({ page }) => {
     const bookId = randomUUID();
     const finishedAt = daysAgoAt(1, 12);


### PR DESCRIPTION
Each book row in the settings library now exposes a copy icon that writes
"Author - Title" to the clipboard, making it easier to look up the book
online.