### PR TITLE
Add dice widget to randomly pick books from wanted list

### DIFF
--- a/client/src/app/reading/reading-library.component.css
+++ b/client/src/app/reading/reading-library.component.css
@@ -123,3 +123,174 @@ h2 {
 .page-loading {
   margin: 60px 0;
 }
+
+.dice-widget {
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+  margin-top: 4px;
+  border-radius: 0.75rem;
+  background: linear-gradient(135deg, hsl(217, 28%, 18%), hsl(217, 28%, 14%));
+  border: 1px solid hsl(217, 19%, 27%);
+}
+
+.dice-widget h4 {
+  color: var(--mat-sys-on-primary);
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  margin: 0;
+}
+
+.dice-hint {
+  color: var(--bt-text-muted);
+  font-size: 12px;
+  margin: 0;
+  line-height: 1.4;
+}
+
+.dice-stage {
+  display: grid;
+  grid-template-columns: 88px 1fr;
+  gap: 16px;
+  align-items: center;
+  padding: 12px 4px;
+}
+
+.dice-result {
+  display: grid;
+  gap: 2px;
+  min-height: 64px;
+  align-content: center;
+}
+
+.dice-result-label {
+  margin: 0;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--bt-text-muted);
+  font-weight: 600;
+}
+
+.dice-result-label--idle {
+  font-style: italic;
+  text-transform: none;
+  letter-spacing: 0;
+  font-weight: 400;
+  font-size: 13px;
+}
+
+.dice-result-title {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--mat-sys-on-primary);
+  line-height: 1.2;
+}
+
+.dice-result-author {
+  margin: 0;
+  font-size: 13px;
+  color: var(--bt-text-muted);
+}
+
+.dice-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.dice {
+  width: 64px;
+  height: 64px;
+  position: relative;
+  margin: 8px auto;
+  transform-style: preserve-3d;
+  transition: transform 0.6s cubic-bezier(0.22, 1.4, 0.36, 1);
+  will-change: transform;
+}
+
+.dice[data-face="1"] { transform: rotateX(-15deg) rotateY(-15deg); }
+.dice[data-face="2"] { transform: rotateX(-15deg) rotateY(-105deg); }
+.dice[data-face="3"] { transform: rotateX(75deg) rotateY(-15deg); }
+.dice[data-face="4"] { transform: rotateX(-105deg) rotateY(-15deg); }
+.dice[data-face="5"] { transform: rotateX(-15deg) rotateY(75deg); }
+.dice[data-face="6"] { transform: rotateX(-15deg) rotateY(165deg); }
+
+.dice--rolling {
+  animation: dice-roll 1.5s cubic-bezier(0.4, 0, 0.2, 1);
+  transition: none;
+}
+
+@keyframes dice-roll {
+  0% {
+    transform: rotateX(0) rotateY(0) rotateZ(0);
+  }
+  50% {
+    transform: rotateX(540deg) rotateY(360deg) rotateZ(90deg) translateY(-12px);
+  }
+  85% {
+    transform: rotateX(900deg) rotateY(540deg) rotateZ(180deg) translateY(0);
+  }
+  100% {
+    transform: rotateX(1080deg) rotateY(720deg) rotateZ(180deg);
+  }
+}
+
+.dice-face {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: repeat(3, 1fr);
+  padding: 8px;
+  border-radius: 10px;
+  background: linear-gradient(135deg, hsl(0, 0%, 98%), hsl(0, 0%, 88%));
+  box-shadow:
+    inset 0 0 0 1px hsl(0, 0%, 78%),
+    inset 0 -4px 8px hsla(0, 0%, 0%, 0.08);
+}
+
+.dice-face--1 { transform: translateZ(32px); }
+.dice-face--6 { transform: rotateY(180deg) translateZ(32px); }
+.dice-face--2 { transform: rotateY(90deg) translateZ(32px); }
+.dice-face--5 { transform: rotateY(-90deg) translateZ(32px); }
+.dice-face--3 { transform: rotateX(-90deg) translateZ(32px); }
+.dice-face--4 { transform: rotateX(90deg) translateZ(32px); }
+
+.pip {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle at 30% 30%,
+    hsl(0, 0%, 30%),
+    hsl(0, 0%, 8%) 80%
+  );
+  align-self: center;
+  justify-self: center;
+  box-shadow: inset 0 1px 2px hsla(0, 0%, 100%, 0.2);
+}
+
+.pip-tl { grid-column: 1; grid-row: 1; }
+.pip-tr { grid-column: 3; grid-row: 1; }
+.pip-ml { grid-column: 1; grid-row: 2; }
+.pip-mm { grid-column: 2; grid-row: 2; }
+.pip-mr { grid-column: 3; grid-row: 2; }
+.pip-bl { grid-column: 1; grid-row: 3; }
+.pip-br { grid-column: 3; grid-row: 3; }
+
+@media (prefers-reduced-motion: reduce) {
+  .dice {
+    transition: none;
+  }
+  .dice--rolling {
+    animation: dice-roll-reduced 0.4s ease-out;
+  }
+  @keyframes dice-roll-reduced {
+    from { opacity: 0.7; }
+    to { opacity: 1; }
+  }
+}

--- a/client/src/app/reading/reading-library.component.css
+++ b/client/src/app/reading/reading-library.component.css
@@ -182,7 +182,7 @@ h2 {
   font-size: 13px;
 }
 
-.dice-result-title {
+h5.dice-result-title {
   margin: 0;
   font-size: 18px;
   font-weight: 700;

--- a/client/src/app/reading/reading-library.component.html
+++ b/client/src/app/reading/reading-library.component.html
@@ -69,7 +69,6 @@
             class="dice"
             [class.dice--rolling]="rolling()"
             [attr.data-face]="diceFace()"
-            [attr.aria-live]="rolling() ? 'off' : 'polite'"
             aria-label="Dice"
             role="img"
           >
@@ -110,7 +109,7 @@
           <div class="dice-result" aria-live="polite">
             @if (pickedBook(); as picked) {
               <p class="dice-result-label">You should read</p>
-              <p class="dice-result-title">{{ picked.title }}</p>
+              <h5 class="dice-result-title">{{ picked.title }}</h5>
               <p class="dice-result-author">{{ picked.author }}</p>
             } @else if (rolling()) {
               <p class="dice-result-label">Rolling…</p>
@@ -136,7 +135,7 @@
             mat-flat-button
             color="primary"
             type="button"
-            [disabled]="rolling() || wantedBooks().length === 0"
+            [disabled]="rolling()"
             (click)="rollWantedDice()"
           >
             {{ pickedBook() ? 'Roll again' : 'Roll the dice' }}

--- a/client/src/app/reading/reading-library.component.html
+++ b/client/src/app/reading/reading-library.component.html
@@ -54,6 +54,95 @@
           ></ng-container>
         }
       </div>
+
+      <section
+        class="dice-widget"
+        aria-labelledby="dice-widget-heading"
+      >
+        <h4 id="dice-widget-heading">Pick your next read</h4>
+        <p class="dice-hint">
+          Roll the dice to pick a random book from your wanted list. Then edit
+          the book to set its page count and move it into Reading in progress.
+        </p>
+        <div class="dice-stage">
+          <div
+            class="dice"
+            [class.dice--rolling]="rolling()"
+            [attr.data-face]="diceFace()"
+            [attr.aria-live]="rolling() ? 'off' : 'polite'"
+            aria-label="Dice"
+            role="img"
+          >
+            <div class="dice-face dice-face--1">
+              <span class="pip pip-mm"></span>
+            </div>
+            <div class="dice-face dice-face--2">
+              <span class="pip pip-tl"></span>
+              <span class="pip pip-br"></span>
+            </div>
+            <div class="dice-face dice-face--3">
+              <span class="pip pip-tl"></span>
+              <span class="pip pip-mm"></span>
+              <span class="pip pip-br"></span>
+            </div>
+            <div class="dice-face dice-face--4">
+              <span class="pip pip-tl"></span>
+              <span class="pip pip-tr"></span>
+              <span class="pip pip-bl"></span>
+              <span class="pip pip-br"></span>
+            </div>
+            <div class="dice-face dice-face--5">
+              <span class="pip pip-tl"></span>
+              <span class="pip pip-tr"></span>
+              <span class="pip pip-mm"></span>
+              <span class="pip pip-bl"></span>
+              <span class="pip pip-br"></span>
+            </div>
+            <div class="dice-face dice-face--6">
+              <span class="pip pip-tl"></span>
+              <span class="pip pip-tr"></span>
+              <span class="pip pip-ml"></span>
+              <span class="pip pip-mr"></span>
+              <span class="pip pip-bl"></span>
+              <span class="pip pip-br"></span>
+            </div>
+          </div>
+          <div class="dice-result" aria-live="polite">
+            @if (pickedBook(); as picked) {
+              <p class="dice-result-label">You should read</p>
+              <p class="dice-result-title">{{ picked.title }}</p>
+              <p class="dice-result-author">{{ picked.author }}</p>
+            } @else if (rolling()) {
+              <p class="dice-result-label">Rolling…</p>
+            } @else {
+              <p class="dice-result-label dice-result-label--idle">
+                Ready when you are.
+              </p>
+            }
+          </div>
+        </div>
+        <div class="dice-actions">
+          @if (pickedBook()) {
+            <button
+              mat-stroked-button
+              type="button"
+              [disabled]="rolling()"
+              (click)="dismissPick()"
+            >
+              Dismiss
+            </button>
+          }
+          <button
+            mat-flat-button
+            color="primary"
+            type="button"
+            [disabled]="rolling() || wantedBooks().length === 0"
+            (click)="rollWantedDice()"
+          >
+            {{ pickedBook() ? 'Roll again' : 'Roll the dice' }}
+          </button>
+        </div>
+      </section>
     </div>
   }
 

--- a/client/src/app/reading/reading-library.component.ts
+++ b/client/src/app/reading/reading-library.component.ts
@@ -1,5 +1,5 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { Component, computed, inject, resource, signal } from '@angular/core';
+import { Component, computed, DestroyRef, effect, inject, resource, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -10,6 +10,13 @@ import {
   NotificationsService,
 } from '@mucsi96/angular-material-theme';
 import { Book, ReadingService } from './reading.service';
+
+type DiceFace = 1 | 2 | 3 | 4 | 5 | 6;
+const DICE_FACES: readonly DiceFace[] = [1, 2, 3, 4, 5, 6];
+const randomFace = (): DiceFace =>
+  DICE_FACES[Math.floor(Math.random() * DICE_FACES.length)];
+const ROLL_DURATION_MS = 1500;
+const FACE_CYCLE_MS = 110;
 
 type BookDraft = {
   title: string;
@@ -43,11 +50,18 @@ const emptyDraft = (): BookDraft => ({
 export class ReadingLibraryComponent {
   private readonly readingService = inject(ReadingService);
   private readonly notifications = inject(NotificationsService);
+  private readonly destroyRef = inject(DestroyRef);
 
   readonly busy = signal(false);
   readonly addingBook = signal(false);
   readonly editingBookId = signal<string | null>(null);
   readonly draft = signal<BookDraft>(emptyDraft());
+
+  readonly rolling = signal(false);
+  readonly diceFace = signal<DiceFace>(1);
+  readonly pickedBook = signal<Book | null>(null);
+  private faceCycleHandle: ReturnType<typeof setInterval> | null = null;
+  private rollTimeoutHandle: ReturnType<typeof setTimeout> | null = null;
 
   readonly books = resource({
     params: () => this.readingService.version(),
@@ -66,6 +80,18 @@ export class ReadingLibraryComponent {
   readonly wantedBooks = computed(
     () => this.books.value()?.filter((book) => book.totalPages === null) ?? []
   );
+
+  constructor() {
+    this.destroyRef.onDestroy(() => this.clearRollTimers());
+    effect(() => {
+      const picked = this.pickedBook();
+      if (!picked) return;
+      const stillWanted = this.wantedBooks().some((b) => b.id === picked.id);
+      if (!stillWanted) {
+        this.pickedBook.set(null);
+      }
+    });
+  }
 
   readonly canSubmit = computed(() => {
     const d = this.draft();
@@ -177,5 +203,46 @@ export class ReadingLibraryComponent {
       return null;
     }
     return `${book.averagePagesPerDay.toFixed(1)} pages/day avg`;
+  }
+
+  rollWantedDice() {
+    if (this.rolling()) return;
+    const candidates = this.wantedBooks();
+    if (candidates.length === 0) return;
+
+    this.pickedBook.set(null);
+    this.rolling.set(true);
+
+    this.faceCycleHandle = setInterval(() => {
+      this.diceFace.set(randomFace());
+    }, FACE_CYCLE_MS);
+
+    this.rollTimeoutHandle = setTimeout(() => {
+      this.clearRollTimers();
+      const pool = this.wantedBooks();
+      if (pool.length === 0) {
+        this.rolling.set(false);
+        return;
+      }
+      const winner = pool[Math.floor(Math.random() * pool.length)];
+      this.diceFace.set(randomFace());
+      this.pickedBook.set(winner);
+      this.rolling.set(false);
+    }, ROLL_DURATION_MS);
+  }
+
+  dismissPick() {
+    this.pickedBook.set(null);
+  }
+
+  private clearRollTimers() {
+    if (this.faceCycleHandle !== null) {
+      clearInterval(this.faceCycleHandle);
+      this.faceCycleHandle = null;
+    }
+    if (this.rollTimeoutHandle !== null) {
+      clearTimeout(this.rollTimeoutHandle);
+      this.rollTimeoutHandle = null;
+    }
   }
 }

--- a/test/tests/reading.spec.ts
+++ b/test/tests/reading.spec.ts
@@ -525,6 +525,78 @@ test.describe('Reading', () => {
     ).toBeVisible();
   });
 
+  test('does not show the wanted-list dice widget when there are no wanted books', async ({
+    page,
+  }) => {
+    const bookId = randomUUID();
+    await insertBook(bookId, 'In Progress Book', 'Author', 200, daysAgoAt(1, 8));
+
+    await page.goto('/settings');
+    const library = page.getByRole('region', { name: 'Books' });
+    await expect(
+      library.getByRole('heading', { name: 'Pick your next read' })
+    ).toBeHidden();
+    await expect(
+      library.getByRole('button', { name: 'Roll the dice' })
+    ).toHaveCount(0);
+  });
+
+  test('rolls the dice and picks a book from the wanted list', async ({
+    page,
+  }) => {
+    await insertBook(randomUUID(), 'Wanted One', 'Author A', null, daysAgoAt(3, 8));
+    await insertBook(randomUUID(), 'Wanted Two', 'Author B', null, daysAgoAt(2, 8));
+    await insertBook(randomUUID(), 'Wanted Three', 'Author C', null, daysAgoAt(1, 8));
+
+    await page.goto('/settings');
+    const widget = page.getByRole('region', { name: 'Pick your next read' });
+    await expect(widget).toBeVisible();
+    await expect(widget.getByText('Ready when you are.')).toBeVisible();
+
+    await widget.getByRole('button', { name: 'Roll the dice' }).click();
+
+    const pickedTitle = widget.locator('.dice-result-title');
+    await expect(pickedTitle).toBeVisible({ timeout: 5000 });
+    await expect(widget.getByText('You should read')).toBeVisible();
+
+    const titleText = (await pickedTitle.textContent())?.trim();
+    expect(['Wanted One', 'Wanted Two', 'Wanted Three']).toContain(titleText);
+
+    await expect(
+      widget.getByRole('button', { name: 'Roll again' })
+    ).toBeVisible();
+    await widget.getByRole('button', { name: 'Dismiss' }).click();
+    await expect(widget.getByText('You should read')).toBeHidden();
+    await expect(
+      widget.getByRole('button', { name: 'Roll the dice' })
+    ).toBeVisible();
+  });
+
+  test('clears the dice pick after the chosen book is moved to in progress', async ({
+    page,
+  }) => {
+    await insertBook(randomUUID(), 'Only Wanted', 'Author', null, daysAgoAt(1, 8));
+
+    await page.goto('/settings');
+    const library = page.getByRole('region', { name: 'Books' });
+    const widget = library.getByRole('region', { name: 'Pick your next read' });
+    await widget.getByRole('button', { name: 'Roll the dice' }).click();
+
+    await expect(widget.getByText('You should read')).toBeVisible({
+      timeout: 5000,
+    });
+    await expect(widget.locator('.dice-result-title')).toHaveText('Only Wanted');
+
+    await library.getByRole('button', { name: 'Edit Only Wanted' }).click();
+    await library.getByLabel('Total pages').fill('220');
+    await library.getByRole('button', { name: 'Save book' }).click();
+
+    await expect(
+      library.getByRole('heading', { name: 'Reading in progress' })
+    ).toBeVisible();
+    await expect(widget).toHaveCount(0);
+  });
+
   test('reflects the configured daily reading goal', async ({ page }) => {
     await setGoals(100, 250, 50);
     const bookId = randomUUID();

--- a/test/tests/reading.spec.ts
+++ b/test/tests/reading.spec.ts
@@ -535,7 +535,7 @@ test.describe('Reading', () => {
     const library = page.getByRole('region', { name: 'Books' });
     await expect(
       library.getByRole('heading', { name: 'Pick your next read' })
-    ).toBeHidden();
+    ).toHaveCount(0);
     await expect(
       library.getByRole('button', { name: 'Roll the dice' })
     ).toHaveCount(0);
@@ -544,9 +544,10 @@ test.describe('Reading', () => {
   test('rolls the dice and picks a book from the wanted list', async ({
     page,
   }) => {
-    await insertBook(randomUUID(), 'Wanted One', 'Author A', null, daysAgoAt(3, 8));
-    await insertBook(randomUUID(), 'Wanted Two', 'Author B', null, daysAgoAt(2, 8));
-    await insertBook(randomUUID(), 'Wanted Three', 'Author C', null, daysAgoAt(1, 8));
+    const wantedTitles = ['Wanted One', 'Wanted Two', 'Wanted Three'];
+    await insertBook(randomUUID(), wantedTitles[0], 'Author A', null, daysAgoAt(3, 8));
+    await insertBook(randomUUID(), wantedTitles[1], 'Author B', null, daysAgoAt(2, 8));
+    await insertBook(randomUUID(), wantedTitles[2], 'Author C', null, daysAgoAt(1, 8));
 
     await page.goto('/settings');
     const widget = page.getByRole('region', { name: 'Pick your next read' });
@@ -555,12 +556,13 @@ test.describe('Reading', () => {
 
     await widget.getByRole('button', { name: 'Roll the dice' }).click();
 
-    const pickedTitle = widget.locator('.dice-result-title');
-    await expect(pickedTitle).toBeVisible({ timeout: 5000 });
-    await expect(widget.getByText('You should read')).toBeVisible();
+    await expect(widget.getByText('You should read')).toBeVisible({
+      timeout: 5000,
+    });
 
+    const pickedTitle = widget.getByRole('heading', { level: 5 });
     const titleText = (await pickedTitle.textContent())?.trim();
-    expect(['Wanted One', 'Wanted Two', 'Wanted Three']).toContain(titleText);
+    expect(wantedTitles).toContain(titleText);
 
     await expect(
       widget.getByRole('button', { name: 'Roll again' })
@@ -585,7 +587,9 @@ test.describe('Reading', () => {
     await expect(widget.getByText('You should read')).toBeVisible({
       timeout: 5000,
     });
-    await expect(widget.locator('.dice-result-title')).toHaveText('Only Wanted');
+    await expect(
+      widget.getByRole('heading', { name: 'Only Wanted', level: 5 })
+    ).toBeVisible();
 
     await library.getByRole('button', { name: 'Edit Only Wanted' }).click();
     await library.getByLabel('Total pages').fill('220');


### PR DESCRIPTION
## Summary
Added an interactive dice widget to the reading library that allows users to randomly select a book from their wanted list. This provides a fun way to decide what to read next.

## Key Changes
- **New dice widget UI component** with a 3D dice visualization that rolls and displays a randomly selected book from the wanted list
- **Dice animation** with 3D transforms and a rolling animation that cycles through faces before landing on the final result
- **Interactive controls** with "Roll the dice" and "Roll again" buttons, plus a dismiss button to clear the selection
- **Smart state management** that automatically clears the picked book if it's moved to "Reading in progress" (i.e., when its page count is set)
- **Accessibility features** including proper ARIA labels, live regions for dynamic content updates, and reduced motion support
- **Comprehensive test coverage** with three new test cases covering the widget visibility, rolling behavior, and state synchronization

## Implementation Details
- The dice widget only appears when there are books in the wanted list
- Rolling animation lasts 1.5 seconds with face cycling every 110ms for a smooth effect
- The picked book is automatically cleared if it's no longer in the wanted list (e.g., after editing to add page count)
- Proper cleanup of timers on component destruction to prevent memory leaks
- Responsive design with Material Design buttons and theme-aware styling

https://claude.ai/code/session_01Hx5b2cCLjZPdvGFFhDCW4k