### PR TITLE
Update route map styling with CyclOSM tiles and route casing

### DIFF
--- a/client/src/app/ride/podium-route-map.component.ts
+++ b/client/src/app/ride/podium-route-map.component.ts
@@ -8,7 +8,30 @@ import {
   input,
   viewChild,
 } from '@angular/core';
-import { LngLatBounds, Map as MapLibreMap } from 'maplibre-gl';
+import {
+  LngLatBounds,
+  Map as MapLibreMap,
+  StyleSpecification,
+} from 'maplibre-gl';
+
+const cyclOsmStyle: StyleSpecification = {
+  version: 8,
+  sources: {
+    cyclosm: {
+      type: 'raster',
+      tiles: [
+        'https://a.tile-cyclosm.openstreetmap.fr/cyclosm/{z}/{x}/{y}.png',
+        'https://b.tile-cyclosm.openstreetmap.fr/cyclosm/{z}/{x}/{y}.png',
+        'https://c.tile-cyclosm.openstreetmap.fr/cyclosm/{z}/{x}/{y}.png',
+      ],
+      tileSize: 256,
+      maxzoom: 20,
+      attribution:
+        '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, tiles by <a href="https://www.cyclosm.org/">CyclOSM</a>',
+    },
+  },
+  layers: [{ id: 'cyclosm', type: 'raster', source: 'cyclosm' }],
+};
 
 @Component({
   standalone: true,
@@ -31,10 +54,10 @@ export class PodiumRouteMapComponent implements AfterViewInit, OnDestroy {
 
     this.map = new MapLibreMap({
       container: this.container().nativeElement,
-      style: 'https://tiles.openfreemap.org/styles/fiord',
+      style: cyclOsmStyle,
       interactive: true,
       scrollZoom: false,
-      attributionControl: false,
+      attributionControl: { compact: true },
     });
 
     this.map.on('error', (event) => {
@@ -52,9 +75,21 @@ export class PodiumRouteMapComponent implements AfterViewInit, OnDestroy {
         },
       });
       map.addLayer({
+        id: 'route-casing',
+        type: 'line',
+        source: 'route',
+        layout: { 'line-cap': 'round', 'line-join': 'round' },
+        paint: {
+          'line-color': '#1a1a1a',
+          'line-width': 5,
+          'line-opacity': 0.6,
+        },
+      });
+      map.addLayer({
         id: 'route-line',
         type: 'line',
         source: 'route',
+        layout: { 'line-cap': 'round', 'line-join': 'round' },
         paint: {
           'line-color': '#ffd700',
           'line-width': 3,


### PR DESCRIPTION
## Summary
Updated the podium route map component to use CyclOSM tiles as the base map layer and enhanced the route visualization with a casing layer for better visibility.

## Key Changes
- Replaced OpenFreeMap tiles with CyclOSM tiles by defining a new `cyclOsmStyle` StyleSpecification constant
- Added a route casing layer (dark semi-transparent line) beneath the main route line for improved contrast and visibility
- Applied consistent line styling (rounded caps and joins) to both route layers
- Enabled attribution control with compact mode to display map tile attribution

## Implementation Details
- The CyclOSM style uses raster tiles from three tile servers for redundancy
- Route casing layer uses a dark color (#1a1a1a) with 60% opacity and 5px width
- Main route line remains golden (#ffd700) with 3px width, now with rounded line caps and joins
- Attribution control changed from disabled to compact mode to properly credit CyclOSM and OpenStreetMap contributors

https://claude.ai/code/session_01KhBhkKF3HrHCGmLnD5Zasc