### PR TITLE
Replace OpenFreeMap with Thunderforest for route map styling

### DIFF
--- a/client/src/app/environment/environment.config.ts
+++ b/client/src/app/environment/environment.config.ts
@@ -7,6 +7,7 @@ export interface EnvironmentConfig {
   mockOAuth2ServerUri: string;
   clientLogUrl: string;
   clientAppName: string;
+  thunderforestApiKey: string;
 }
 
 export const ENVIRONMENT_CONFIG = new InjectionToken<EnvironmentConfig>('ENVIRONMENT_CONFIG');

--- a/client/src/app/ride/podium-route-map.component.ts
+++ b/client/src/app/ride/podium-route-map.component.ts
@@ -5,10 +5,12 @@ import {
   ElementRef,
   HostListener,
   OnDestroy,
+  inject,
   input,
   viewChild,
 } from '@angular/core';
-import { LngLatBounds, Map as MapLibreMap } from 'maplibre-gl';
+import { LngLatBounds, Map as MapLibreMap, StyleSpecification } from 'maplibre-gl';
+import { ENVIRONMENT_CONFIG } from '../environment/environment.config';
 
 @Component({
   standalone: true,
@@ -22,6 +24,7 @@ export class PodiumRouteMapComponent implements AfterViewInit, OnDestroy {
   readonly longitudes = input.required<number[]>();
 
   private readonly container = viewChild.required<ElementRef<HTMLDivElement>>('mapContainer');
+  private readonly environment = inject(ENVIRONMENT_CONFIG);
   private map?: MapLibreMap;
 
   ngAfterViewInit(): void {
@@ -31,7 +34,7 @@ export class PodiumRouteMapComponent implements AfterViewInit, OnDestroy {
 
     this.map = new MapLibreMap({
       container: this.container().nativeElement,
-      style: 'https://tiles.openfreemap.org/styles/fiord',
+      style: this.outdoorStyle(),
       interactive: true,
       scrollZoom: false,
       attributionControl: false,
@@ -73,6 +76,31 @@ export class PodiumRouteMapComponent implements AfterViewInit, OnDestroy {
   @HostListener('touchstart', ['$event'])
   onPointer(event: Event): void {
     event.stopPropagation();
+  }
+
+  private outdoorStyle(): StyleSpecification {
+    const apiKey = this.environment.thunderforestApiKey;
+    return {
+      version: 8,
+      sources: {
+        'thunderforest-outdoors': {
+          type: 'raster',
+          tiles: [
+            `https://tile.thunderforest.com/outdoors/{z}/{x}/{y}.png?apikey=${apiKey}`,
+          ],
+          tileSize: 256,
+          attribution:
+            '&copy; <a href="https://www.thunderforest.com/">Thunderforest</a>, &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+        },
+      },
+      layers: [
+        {
+          id: 'thunderforest-outdoors',
+          type: 'raster',
+          source: 'thunderforest-outdoors',
+        },
+      ],
+    };
   }
 
   ngOnDestroy(): void {

--- a/server/src/main/java/mucsi96/traininglog/core/EnvironmentController.java
+++ b/server/src/main/java/mucsi96/traininglog/core/EnvironmentController.java
@@ -28,6 +28,9 @@ public class EnvironmentController {
   @Value("${client-app-name:}")
   private String clientAppName;
 
+  @Value("${thunderforest-api-key:}")
+  private String thunderforestApiKey;
+
   @GetMapping("/environment")
   public ConfigResponse getConfig() {
     return new ConfigResponse(
@@ -36,7 +39,8 @@ public class EnvironmentController {
         clientId,
         mockOAuth2ServerUri,
         clientLogUrl,
-        clientAppName);
+        clientAppName,
+        thunderforestApiKey);
   }
 
   public record ConfigResponse(
@@ -45,6 +49,7 @@ public class EnvironmentController {
       String apiClientId,
       String mockOAuth2ServerUri,
       String clientLogUrl,
-      String clientAppName) {
+      String clientAppName,
+      String thunderforestApiKey) {
   }
 }


### PR DESCRIPTION
## Summary
This PR replaces the OpenFreeMap tile service with Thunderforest for the route map component, enabling better map styling and customization through an API key-based configuration.

## Key Changes
- **Map styling**: Migrated from hardcoded OpenFreeMap URL to a dynamic Thunderforest outdoor style configuration
- **Configuration management**: Added `thunderforestApiKey` to the environment configuration pipeline
  - Extended `EnvironmentConfig` interface to include the API key
  - Updated `EnvironmentController` to expose the Thunderforest API key from server configuration
  - Injected environment config into `PodiumRouteMapComponent`
- **Style implementation**: Created `outdoorStyle()` method that builds a MapLibre `StyleSpecification` with Thunderforest raster tiles and proper attribution

## Implementation Details
- The Thunderforest API key is injected via Angular's dependency injection system using `ENVIRONMENT_CONFIG` token
- The map style is now dynamically constructed as a raster tile layer with proper attribution for both Thunderforest and OpenStreetMap
- The implementation maintains the same map behavior (interactive, no scroll zoom, no attribution control) while improving the visual appearance with Thunderforest's outdoor map style

https://claude.ai/code/session_0111rFSwga5NgUPc2Uh9NuYp