### PR TITLE
Add dark theme and external map link to route map

### DIFF
--- a/client/src/app/ride/podium-route-map.component.css
+++ b/client/src/app/ride/podium-route-map.component.css
@@ -2,9 +2,39 @@
   display: block;
 }
 
+.podium-map-wrap {
+  position: relative;
+}
+
 .podium-map {
   height: 200px;
   width: 100%;
   border-radius: 0.5rem;
   overflow: hidden;
+}
+
+.podium-map-link {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 0.5rem;
+  color: #e6edf3;
+  background: rgba(14, 17, 22, 0.78);
+  border: 1px solid rgba(230, 237, 243, 0.18);
+  text-decoration: none;
+}
+
+.podium-map-link:hover {
+  background: rgba(14, 17, 22, 0.92);
+}
+
+.podium-map-link mat-icon {
+  font-size: 1.125rem;
+  width: 1.125rem;
+  height: 1.125rem;
 }

--- a/client/src/app/ride/podium-route-map.component.html
+++ b/client/src/app/ride/podium-route-map.component.html
@@ -1,6 +1,18 @@
-<div
-  #mapContainer
-  class="podium-map"
-  data-testid="podium-map"
-  aria-label="Segment route mini map"
-></div>
+<div class="podium-map-wrap">
+  <div
+    #mapContainer
+    class="podium-map"
+    data-testid="podium-map"
+    aria-label="Segment route mini map"
+  ></div>
+  <a
+    class="podium-map-link"
+    data-testid="podium-map-link"
+    [href]="externalMapUrl()"
+    target="_blank"
+    rel="noopener noreferrer"
+    aria-label="Open segment in geojson.io"
+  >
+    <mat-icon aria-hidden="true">open_in_new</mat-icon>
+  </a>
+</div>

--- a/client/src/app/ride/podium-route-map.component.ts
+++ b/client/src/app/ride/podium-route-map.component.ts
@@ -3,18 +3,24 @@ import {
   ChangeDetectionStrategy,
   Component,
   ElementRef,
-  HostListener,
   OnDestroy,
+  computed,
   inject,
   input,
   viewChild,
 } from '@angular/core';
-import { LngLatBounds, Map as MapLibreMap, StyleSpecification } from 'maplibre-gl';
+import { MatIconModule } from '@angular/material/icon';
+import {
+  LngLatBounds,
+  Map as MapLibreMap,
+  StyleSpecification,
+} from 'maplibre-gl';
 import { ENVIRONMENT_CONFIG } from '../environment/environment.config';
 
 @Component({
   standalone: true,
   selector: 'app-podium-route-map',
+  imports: [MatIconModule],
   templateUrl: './podium-route-map.component.html',
   styleUrl: './podium-route-map.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -23,18 +29,47 @@ export class PodiumRouteMapComponent implements AfterViewInit, OnDestroy {
   readonly latitudes = input.required<number[]>();
   readonly longitudes = input.required<number[]>();
 
-  private readonly container = viewChild.required<ElementRef<HTMLDivElement>>('mapContainer');
+  readonly externalMapUrl = computed(() => {
+    const coordinates = this.coordinates();
+    const geojson = {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          properties: {},
+          geometry: { type: 'LineString', coordinates },
+        },
+      ],
+    };
+    return `https://geojson.io/#data=data:application/json,${encodeURIComponent(
+      JSON.stringify(geojson)
+    )}`;
+  });
+
+  private readonly container =
+    viewChild.required<ElementRef<HTMLDivElement>>('mapContainer');
   private readonly environment = inject(ENVIRONMENT_CONFIG);
   private map?: MapLibreMap;
+  private destroyed = false;
 
-  ngAfterViewInit(): void {
-    const lats = this.latitudes();
-    const lngs = this.longitudes();
-    const coords: [number, number][] = lats.map((lat, i) => [lngs[i], lat]);
+  async ngAfterViewInit(): Promise<void> {
+    const coords = this.coordinates();
+
+    let style: StyleSpecification;
+    try {
+      style = await this.darkOutdoorsStyle();
+    } catch (error) {
+      console.warn('[podium-route-map] Failed to load basemap style', error);
+      return;
+    }
+
+    if (this.destroyed) {
+      return;
+    }
 
     this.map = new MapLibreMap({
       container: this.container().nativeElement,
-      style: this.outdoorStyle(),
+      style,
       interactive: true,
       scrollZoom: false,
       attributionControl: false,
@@ -71,39 +106,175 @@ export class PodiumRouteMapComponent implements AfterViewInit, OnDestroy {
     });
   }
 
-  @HostListener('click', ['$event'])
-  @HostListener('pointerdown', ['$event'])
-  @HostListener('touchstart', ['$event'])
-  onPointer(event: Event): void {
-    event.stopPropagation();
+  private coordinates(): [number, number][] {
+    const lats = this.latitudes();
+    const lngs = this.longitudes();
+    return lats.map((lat, i) => [lngs[i], lat]);
   }
 
-  private outdoorStyle(): StyleSpecification {
+  private async darkOutdoorsStyle(): Promise<StyleSpecification> {
     const apiKey = this.environment.thunderforestApiKey;
-    return {
-      version: 8,
-      sources: {
-        'thunderforest-outdoors': {
-          type: 'raster',
-          tiles: [
-            `https://tile.thunderforest.com/outdoors/{z}/{x}/{y}.png?apikey=${apiKey}`,
-          ],
-          tileSize: 256,
-          attribution:
-            '&copy; <a href="https://www.thunderforest.com/">Thunderforest</a>, &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
-        },
-      },
-      layers: [
-        {
-          id: 'thunderforest-outdoors',
-          type: 'raster',
-          source: 'thunderforest-outdoors',
-        },
-      ],
-    };
+    const response = await fetch(
+      `https://api.thunderforest.com/styles/outdoors/style.json?apikey=${apiKey}`
+    );
+    if (!response.ok) {
+      throw new Error(`Thunderforest style request failed: ${response.status}`);
+    }
+    const style = (await response.json()) as StyleSpecification;
+    return applyDarkTheme(style);
   }
 
   ngOnDestroy(): void {
+    this.destroyed = true;
     this.map?.remove();
   }
+}
+
+const FILL_PROPERTIES = [
+  'fill-color',
+  'fill-outline-color',
+  'fill-extrusion-color',
+];
+
+type Hsl = { h: number; s: number; l: number; a: number };
+
+// Recolours the supplied Thunderforest Outdoors vector style for a dark theme:
+// land/water polygons collapse to near-black, line work is lifted to stay
+// legible on the dark base, and labels become light with a dark halo.
+function applyDarkTheme(style: StyleSpecification): StyleSpecification {
+  const layers = (style.layers ?? []).map((layer) => {
+    if (layer.type === 'background') {
+      return {
+        ...layer,
+        paint: { ...layer.paint, 'background-color': '#0e1116' },
+      };
+    }
+
+    if (layer.type === 'symbol') {
+      const paint = layer.paint as Record<string, unknown> | undefined;
+      return {
+        ...layer,
+        paint: {
+          ...paint,
+          'text-color': '#c2c9d1',
+          'text-halo-color': '#0b0e12',
+          'text-halo-width': 1.2,
+          ...(paint?.['icon-color'] ? { 'icon-color': '#9aa4af' } : {}),
+        },
+      };
+    }
+
+    const paint: Record<string, unknown> = { ...layer.paint };
+    for (const key of FILL_PROPERTIES) {
+      if (paint[key] != null) {
+        paint[key] = mapColors(paint[key], darkenFill);
+      }
+    }
+    if (paint['line-color'] != null) {
+      paint['line-color'] = mapColors(paint['line-color'], toneLine);
+    }
+    return { ...layer, paint };
+  });
+
+  return { ...style, layers };
+}
+
+// Walks a paint value, applying the colour transform to any colour-string leaf
+// while leaving expression operators, stops and numbers untouched.
+function mapColors(value: unknown, transform: (color: Hsl) => Hsl): unknown {
+  if (typeof value === 'string') {
+    const parsed = parseColor(value);
+    return parsed ? formatColor(transform(parsed)) : value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => mapColors(entry, transform));
+  }
+  return value;
+}
+
+// Polygons sink to a very dark tint of their original hue.
+function darkenFill(color: Hsl): Hsl {
+  return { ...color, s: color.s * 0.5, l: 0.05 + color.l * 0.12 };
+}
+
+// Lines (roads, paths, contours, waterways) keep their hue but are pulled to a
+// mid lightness so they read against the dark base.
+function toneLine(color: Hsl): Hsl {
+  return { ...color, s: color.s * 0.55, l: 0.34 + color.l * 0.22 };
+}
+
+const NAMED_COLORS: Record<string, string> = {
+  white: '#ffffff',
+  black: '#000000',
+  gray: '#808080',
+  grey: '#808080',
+};
+
+function parseColor(input: string): Hsl | null {
+  const value = (NAMED_COLORS[input.trim().toLowerCase()] ?? input).trim().toLowerCase();
+
+  const hex = value.match(/^#([0-9a-f]{3,8})$/);
+  if (hex) {
+    const digits = hex[1];
+    const pair = (start: number, len: number) =>
+      parseInt(len === 1 ? digits[start] + digits[start] : digits.substr(start, len), 16);
+    if (digits.length === 3 || digits.length === 4) {
+      return rgbToHsl(pair(0, 1), pair(1, 1), pair(2, 1), digits.length === 4 ? pair(3, 1) / 255 : 1);
+    }
+    if (digits.length === 6 || digits.length === 8) {
+      return rgbToHsl(pair(0, 2), pair(2, 2), pair(4, 2), digits.length === 8 ? pair(6, 2) / 255 : 1);
+    }
+    return null;
+  }
+
+  const rgb = value.match(/^rgba?\(([^)]+)\)$/);
+  if (rgb) {
+    const parts = rgb[1].split(',').map((p) => parseFloat(p));
+    if (parts.length < 3 || parts.slice(0, 3).some(Number.isNaN)) {
+      return null;
+    }
+    return rgbToHsl(parts[0], parts[1], parts[2], parts[3] ?? 1);
+  }
+
+  const hsl = value.match(/^hsla?\(([^)]+)\)$/);
+  if (hsl) {
+    const parts = hsl[1].replace(/%/g, '').split(',').map((p) => parseFloat(p));
+    if (parts.length < 3 || parts.slice(0, 3).some(Number.isNaN)) {
+      return null;
+    }
+    return { h: parts[0], s: parts[1] / 100, l: parts[2] / 100, a: parts[3] ?? 1 };
+  }
+
+  return null;
+}
+
+function formatColor({ h, s, l, a }: Hsl): string {
+  return `hsla(${Math.round(h)}, ${Math.round(s * 100)}%, ${Math.round(l * 100)}%, ${a})`;
+}
+
+function rgbToHsl(r: number, g: number, b: number, a: number): Hsl {
+  const rn = r / 255;
+  const gn = g / 255;
+  const bn = b / 255;
+  const max = Math.max(rn, gn, bn);
+  const min = Math.min(rn, gn, bn);
+  const l = (max + min) / 2;
+  const delta = max - min;
+
+  if (delta === 0) {
+    return { h: 0, s: 0, l, a };
+  }
+
+  const s = delta / (1 - Math.abs(2 * l - 1));
+  let h: number;
+  if (max === rn) {
+    h = ((gn - bn) / delta) % 6;
+  } else if (max === gn) {
+    h = (bn - rn) / delta + 2;
+  } else {
+    h = (rn - gn) / delta + 4;
+  }
+  h = (h * 60 + 360) % 360;
+
+  return { h, s, l, a };
 }

--- a/client/src/app/ride/ride.component.css
+++ b/client/src/app/ride/ride.component.css
@@ -45,19 +45,6 @@ h2 {
   box-shadow: 0 1px 3px rgb(0 0 0 / 0.2);
   border-left: 4px solid var(--podium-medal-color);
   color: inherit;
-  text-decoration: none;
-  transition: background-color 120ms ease, box-shadow 120ms ease;
-}
-
-.podium-panel:hover,
-.podium-panel:focus-visible {
-  background: var(--mat-sys-surface-container-high, var(--mat-sys-surface-container));
-  box-shadow: 0 2px 6px rgb(0 0 0 / 0.3);
-}
-
-.podium-panel:focus-visible {
-  outline: 2px solid var(--podium-medal-color);
-  outline-offset: 2px;
 }
 
 .podium-panel[data-position="1"] {

--- a/client/src/app/ride/ride.component.html
+++ b/client/src/app/ride/ride.component.html
@@ -5,15 +5,12 @@
 <div class="page-loading"><bt-bar-loader /></div>
 } @else if (today && period) {
 @if (podium) {
-<a
+<section
   class="podium-panel"
   data-testid="podium-banner"
   [attr.data-period]="podium.period"
   [attr.data-position]="podium.position"
-  [attr.aria-label]="podium.message + ' — open Strava segment'"
-  [href]="podium.segmentUrl"
-  target="_blank"
-  rel="noopener noreferrer"
+  [attr.aria-label]="podium.message"
 >
   <header class="podium-header">
     <mat-icon class="podium-medal" aria-hidden="true">emoji_events</mat-icon>
@@ -90,7 +87,7 @@
     }
   </ul>
   }
-</a>
+</section>
 }
 @if ((period.time ?? 0) > 0) {
 <section>

--- a/test/tests/podium.spec.ts
+++ b/test/tests/podium.spec.ts
@@ -190,9 +190,6 @@ test.describe('Podium messages', () => {
     await expect(panel).toBeVisible();
     await expect(panel).toContainText('2nd place all-time on UndAbflug');
     await expect(panel).toHaveAttribute('data-position', '2');
-    await expect(panel).toHaveAttribute('href', /\/segments\/42$/);
-    await expect(panel).toHaveAttribute('target', '_blank');
-    await expect(panel).toHaveAttribute('rel', /noopener/);
 
     await expect(page.getByTestId('podium-distance')).toContainText('1.2 km');
     await expect(page.getByTestId('podium-time')).toContainText('3:30');
@@ -255,5 +252,10 @@ test.describe('Podium messages', () => {
 
     await expect(banner.getByTestId('podium-map')).toBeVisible();
     await expect(banner.getByTestId('podium-elevation-chart')).toBeVisible();
+
+    const mapLink = banner.getByTestId('podium-map-link');
+    await expect(mapLink).toHaveAttribute('href', /^https:\/\/geojson\.io\/#data=/);
+    await expect(mapLink).toHaveAttribute('target', '_blank');
+    await expect(mapLink).toHaveAttribute('rel', /noopener/);
   });
 });


### PR DESCRIPTION
## Summary
Enhanced the podium route map component with a dark theme and added a link to view the route in geojson.io. The map now fetches and applies a dark theme transformation to the Thunderforest Outdoors vector style, and users can open the segment route in an external map editor.

## Key Changes
- **Dark theme support**: Implemented `applyDarkTheme()` function that transforms the Thunderforest Outdoors vector style for dark mode by:
  - Darkening fill colors (land/water polygons)
  - Adjusting line colors (roads, paths, contours) for legibility on dark backgrounds
  - Lightening text labels with dark halos
  - Changing background to near-black (#0e1116)

- **Color parsing and transformation**: Added comprehensive color parsing utilities (`parseColor()`, `formatColor()`, `rgbToHsl()`) to handle hex, rgb/rgba, and hsl/hsla color formats, enabling dynamic color transformations

- **External map link**: Added a button in the top-right corner of the map that opens the segment route in geojson.io with the route coordinates pre-loaded

- **Async style loading**: Changed `ngAfterViewInit()` to async to fetch the style from Thunderforest API, with error handling and cleanup on component destruction

- **Component refactoring**:
  - Removed `@HostListener` decorators (no longer needed)
  - Extracted coordinate transformation to `coordinates()` method
  - Added `MatIconModule` import for the external link icon
  - Changed podium panel from anchor to section element (link functionality moved to map component)

- **Styling updates**: Added `.podium-map-wrap` wrapper and `.podium-map-link` button styles with hover effects

- **Test updates**: Updated tests to verify the new geojson.io link instead of the removed Strava segment link

https://claude.ai/code/session_01NN8Y9cgdQpwF9dbjA8cj2n