### PR TITLE
Build dark Outdoors basemap from the outdoors-v2 vector tileset

### DIFF
--- a/client/src/app/ride/podium-route-map.component.ts
+++ b/client/src/app/ride/podium-route-map.component.ts
@@ -50,26 +50,13 @@ export class PodiumRouteMapComponent implements AfterViewInit, OnDestroy {
     viewChild.required<ElementRef<HTMLDivElement>>('mapContainer');
   private readonly environment = inject(ENVIRONMENT_CONFIG);
   private map?: MapLibreMap;
-  private destroyed = false;
 
-  async ngAfterViewInit(): Promise<void> {
+  ngAfterViewInit(): void {
     const coords = this.coordinates();
-
-    let style: StyleSpecification;
-    try {
-      style = await this.darkOutdoorsStyle();
-    } catch (error) {
-      console.warn('[podium-route-map] Failed to load basemap style', error);
-      return;
-    }
-
-    if (this.destroyed) {
-      return;
-    }
 
     this.map = new MapLibreMap({
       container: this.container().nativeElement,
-      style,
+      style: darkOutdoorsStyle(this.environment.thunderforestApiKey),
       interactive: true,
       scrollZoom: false,
       attributionControl: false,
@@ -112,169 +99,265 @@ export class PodiumRouteMapComponent implements AfterViewInit, OnDestroy {
     return lats.map((lat, i) => [lngs[i], lat]);
   }
 
-  private async darkOutdoorsStyle(): Promise<StyleSpecification> {
-    const apiKey = this.environment.thunderforestApiKey;
-    const response = await fetch(
-      `https://api.thunderforest.com/styles/outdoors/style.json?apikey=${apiKey}`
-    );
-    if (!response.ok) {
-      throw new Error(`Thunderforest style request failed: ${response.status}`);
-    }
-    const style = (await response.json()) as StyleSpecification;
-    return applyDarkTheme(style);
-  }
-
   ngOnDestroy(): void {
-    this.destroyed = true;
     this.map?.remove();
   }
 }
 
-const FILL_PROPERTIES = [
-  'fill-color',
-  'fill-outline-color',
-  'fill-extrusion-color',
-];
-
-type Hsl = { h: number; s: number; l: number; a: number };
-
-// Recolours the supplied Thunderforest Outdoors vector style for a dark theme:
-// land/water polygons collapse to near-black, line work is lifted to stay
-// legible on the dark base, and labels become light with a dark halo.
-function applyDarkTheme(style: StyleSpecification): StyleSpecification {
-  const layers = (style.layers ?? []).map((layer) => {
-    if (layer.type === 'background') {
-      return {
-        ...layer,
-        paint: { ...layer.paint, 'background-color': '#0e1116' },
-      };
-    }
-
-    if (layer.type === 'symbol') {
-      const paint = layer.paint as Record<string, unknown> | undefined;
-      return {
-        ...layer,
+// Dark theme authored directly against Thunderforest's `outdoors-v2` vector
+// tileset (https://www.thunderforest.com/docs/thunderforest.outdoors-v2/).
+// There is no ready-made dark Outdoors style.json, so we draw the source
+// layers ourselves: dark land/water, subtle hillshade relief and contours, and
+// the signed cycling / mountain-biking / hiking routes that make it an outdoors
+// map. Labels are intentionally omitted to keep the small mini-map legible and
+// avoid a font dependency. The gold route line is added on top at runtime.
+function darkOutdoorsStyle(apiKey: string): StyleSpecification {
+  return {
+    version: 8,
+    sources: {
+      outdoors: {
+        type: 'vector',
+        url: `https://api.thunderforest.com/thunderforest.outdoors-v2.json?apikey=${apiKey}`,
+        attribution:
+          '&copy; <a href="https://www.thunderforest.com/">Thunderforest</a>, &copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+      },
+    },
+    layers: [
+      {
+        id: 'background',
+        type: 'background',
+        paint: { 'background-color': '#0e1116' },
+      },
+      {
+        id: 'landcover-lowzoom',
+        type: 'fill',
+        source: 'outdoors',
+        'source-layer': 'landcover-lowzoom',
+        paint: { 'fill-color': '#141d18', 'fill-antialias': false },
+      },
+      {
+        id: 'landcover',
+        type: 'fill',
+        source: 'outdoors',
+        'source-layer': 'landcover',
         paint: {
-          ...paint,
-          'text-color': '#c2c9d1',
-          'text-halo-color': '#0b0e12',
-          'text-halo-width': 1.2,
-          ...(paint?.['icon-color'] ? { 'icon-color': '#9aa4af' } : {}),
+          'fill-antialias': false,
+          'fill-color': [
+            'match',
+            ['get', 'type'],
+            ['wood', 'forest'],
+            '#13241b',
+            ['orchard', 'vineyard'],
+            '#172419',
+            ['scrub', 'heath', 'grassland', 'grass', 'meadow', 'farmland', 'farm'],
+            '#172017',
+            ['scree', 'bare_rock', 'shingle'],
+            '#20222b',
+            ['sand', 'beach'],
+            '#26231b',
+            '#161e18',
+          ],
         },
-      };
-    }
-
-    const paint: Record<string, unknown> = { ...layer.paint };
-    for (const key of FILL_PROPERTIES) {
-      if (paint[key] != null) {
-        paint[key] = mapColors(paint[key], darkenFill);
-      }
-    }
-    if (paint['line-color'] != null) {
-      paint['line-color'] = mapColors(paint['line-color'], toneLine);
-    }
-    return { ...layer, paint };
-  });
-
-  return { ...style, layers };
-}
-
-// Walks a paint value, applying the colour transform to any colour-string leaf
-// while leaving expression operators, stops and numbers untouched.
-function mapColors(value: unknown, transform: (color: Hsl) => Hsl): unknown {
-  if (typeof value === 'string') {
-    const parsed = parseColor(value);
-    return parsed ? formatColor(transform(parsed)) : value;
-  }
-  if (Array.isArray(value)) {
-    return value.map((entry) => mapColors(entry, transform));
-  }
-  return value;
-}
-
-// Polygons sink to a very dark tint of their original hue.
-function darkenFill(color: Hsl): Hsl {
-  return { ...color, s: color.s * 0.5, l: 0.05 + color.l * 0.12 };
-}
-
-// Lines (roads, paths, contours, waterways) keep their hue but are pulled to a
-// mid lightness so they read against the dark base.
-function toneLine(color: Hsl): Hsl {
-  return { ...color, s: color.s * 0.55, l: 0.34 + color.l * 0.22 };
-}
-
-const NAMED_COLORS: Record<string, string> = {
-  white: '#ffffff',
-  black: '#000000',
-  gray: '#808080',
-  grey: '#808080',
-};
-
-function parseColor(input: string): Hsl | null {
-  const value = (NAMED_COLORS[input.trim().toLowerCase()] ?? input).trim().toLowerCase();
-
-  const hex = value.match(/^#([0-9a-f]{3,8})$/);
-  if (hex) {
-    const digits = hex[1];
-    const pair = (start: number, len: number) =>
-      parseInt(len === 1 ? digits[start] + digits[start] : digits.substr(start, len), 16);
-    if (digits.length === 3 || digits.length === 4) {
-      return rgbToHsl(pair(0, 1), pair(1, 1), pair(2, 1), digits.length === 4 ? pair(3, 1) / 255 : 1);
-    }
-    if (digits.length === 6 || digits.length === 8) {
-      return rgbToHsl(pair(0, 2), pair(2, 2), pair(4, 2), digits.length === 8 ? pair(6, 2) / 255 : 1);
-    }
-    return null;
-  }
-
-  const rgb = value.match(/^rgba?\(([^)]+)\)$/);
-  if (rgb) {
-    const parts = rgb[1].split(',').map((p) => parseFloat(p));
-    if (parts.length < 3 || parts.slice(0, 3).some(Number.isNaN)) {
-      return null;
-    }
-    return rgbToHsl(parts[0], parts[1], parts[2], parts[3] ?? 1);
-  }
-
-  const hsl = value.match(/^hsla?\(([^)]+)\)$/);
-  if (hsl) {
-    const parts = hsl[1].replace(/%/g, '').split(',').map((p) => parseFloat(p));
-    if (parts.length < 3 || parts.slice(0, 3).some(Number.isNaN)) {
-      return null;
-    }
-    return { h: parts[0], s: parts[1] / 100, l: parts[2] / 100, a: parts[3] ?? 1 };
-  }
-
-  return null;
-}
-
-function formatColor({ h, s, l, a }: Hsl): string {
-  return `hsla(${Math.round(h)}, ${Math.round(s * 100)}%, ${Math.round(l * 100)}%, ${a})`;
-}
-
-function rgbToHsl(r: number, g: number, b: number, a: number): Hsl {
-  const rn = r / 255;
-  const gn = g / 255;
-  const bn = b / 255;
-  const max = Math.max(rn, gn, bn);
-  const min = Math.min(rn, gn, bn);
-  const l = (max + min) / 2;
-  const delta = max - min;
-
-  if (delta === 0) {
-    return { h: 0, s: 0, l, a };
-  }
-
-  const s = delta / (1 - Math.abs(2 * l - 1));
-  let h: number;
-  if (max === rn) {
-    h = ((gn - bn) / delta) % 6;
-  } else if (max === gn) {
-    h = (bn - rn) / delta + 2;
-  } else {
-    h = (rn - gn) / delta + 4;
-  }
-  h = (h * 60 + 360) % 360;
-
-  return { h, s, l, a };
+      },
+      {
+        id: 'landuse',
+        type: 'fill',
+        source: 'outdoors',
+        'source-layer': 'landuse',
+        paint: {
+          'fill-antialias': false,
+          'fill-color': [
+            'match',
+            ['get', 'type'],
+            ['park', 'recreation_ground', 'village_green', 'garden', 'golf_course', 'common', 'meadow', 'pitch'],
+            '#14211a',
+            ['residential', 'living_street'],
+            '#14181f',
+            ['industrial', 'railway', 'commercial', 'retail', 'garages'],
+            '#181b21',
+            ['cemetery', 'grave_yard'],
+            '#161f1a',
+            ['quarry', 'landfill', 'construction'],
+            '#201d19',
+            '#15191f',
+          ],
+        },
+      },
+      {
+        id: 'wetland',
+        type: 'fill',
+        source: 'outdoors',
+        'source-layer': 'wetland',
+        paint: { 'fill-color': '#15211f', 'fill-antialias': false },
+      },
+      {
+        id: 'glacier',
+        type: 'fill',
+        source: 'outdoors',
+        'source-layer': 'glacier',
+        paint: { 'fill-color': '#1d2731', 'fill-antialias': false },
+      },
+      {
+        id: 'hillshade',
+        type: 'fill',
+        source: 'outdoors',
+        'source-layer': 'hillshade',
+        paint: {
+          'fill-antialias': false,
+          'fill-color': [
+            'interpolate',
+            ['linear'],
+            ['get', 'level'],
+            110,
+            '#04060b',
+            150,
+            '#0e1116',
+            200,
+            '#1a1f28',
+            230,
+            '#232b36',
+          ],
+          'fill-opacity': 0.5,
+        },
+      },
+      {
+        id: 'contours',
+        type: 'line',
+        source: 'outdoors',
+        'source-layer': 'elevation',
+        minzoom: 11,
+        paint: { 'line-color': '#2c2820', 'line-width': 0.5, 'line-opacity': 0.55 },
+      },
+      {
+        id: 'ocean',
+        type: 'fill',
+        source: 'outdoors',
+        'source-layer': 'ocean',
+        paint: { 'fill-color': '#0f2330', 'fill-antialias': false },
+      },
+      {
+        id: 'water',
+        type: 'fill',
+        source: 'outdoors',
+        'source-layer': 'water',
+        paint: { 'fill-color': '#132c3b', 'fill-antialias': false },
+      },
+      {
+        id: 'waterway',
+        type: 'line',
+        source: 'outdoors',
+        'source-layer': 'waterway',
+        paint: {
+          'line-color': '#214459',
+          'line-width': ['interpolate', ['linear'], ['zoom'], 10, 0.4, 16, 2],
+        },
+      },
+      {
+        id: 'building',
+        type: 'fill',
+        source: 'outdoors',
+        'source-layer': 'building',
+        minzoom: 14,
+        paint: { 'fill-color': '#1a1f28', 'fill-outline-color': '#242b35' },
+      },
+      {
+        id: 'railway',
+        type: 'line',
+        source: 'outdoors',
+        'source-layer': 'railway',
+        paint: {
+          'line-color': '#3f4651',
+          'line-width': ['interpolate', ['linear'], ['zoom'], 8, 0.4, 14, 1.2],
+          'line-dasharray': [3, 3],
+        },
+      },
+      {
+        id: 'road',
+        type: 'line',
+        source: 'outdoors',
+        'source-layer': 'road',
+        layout: { 'line-cap': 'round', 'line-join': 'round' },
+        paint: {
+          'line-color': [
+            'match',
+            ['get', 'highway'],
+            ['motorway', 'motorway_link', 'trunk', 'trunk_link'],
+            '#5a6571',
+            ['primary', 'primary_link'],
+            '#4e5762',
+            ['secondary', 'secondary_link', 'tertiary', 'tertiary_link'],
+            '#434b56',
+            ['track'],
+            '#3c3a30',
+            '#363d46',
+          ],
+          'line-width': ['interpolate', ['linear'], ['zoom'], 6, 0.4, 11, 1, 16, 3.5],
+        },
+      },
+      {
+        id: 'path',
+        type: 'line',
+        source: 'outdoors',
+        'source-layer': 'path',
+        minzoom: 12,
+        paint: {
+          'line-color': '#6f5a44',
+          'line-width': ['interpolate', ['linear'], ['zoom'], 12, 0.5, 16, 1.4],
+          'line-dasharray': [2, 1.5],
+        },
+      },
+      {
+        id: 'cycling-lowzoom',
+        type: 'line',
+        source: 'outdoors',
+        'source-layer': 'cycling-lowzoom',
+        layout: { 'line-cap': 'round', 'line-join': 'round' },
+        paint: { 'line-color': '#2f7d68', 'line-width': 1, 'line-opacity': 0.55 },
+      },
+      {
+        id: 'cycling',
+        type: 'line',
+        source: 'outdoors',
+        'source-layer': 'cycling',
+        layout: { 'line-cap': 'round', 'line-join': 'round' },
+        paint: { 'line-color': '#2f7d68', 'line-width': 1.1, 'line-opacity': 0.6 },
+      },
+      {
+        id: 'mountain-biking',
+        type: 'line',
+        source: 'outdoors',
+        'source-layer': 'mountain-biking',
+        paint: {
+          'line-color': '#7a4f2e',
+          'line-width': 1,
+          'line-opacity': 0.55,
+          'line-dasharray': [3, 2],
+        },
+      },
+      {
+        id: 'hiking',
+        type: 'line',
+        source: 'outdoors',
+        'source-layer': 'hiking',
+        paint: {
+          'line-color': '#9c5a3a',
+          'line-width': 1,
+          'line-opacity': 0.5,
+          'line-dasharray': [4, 2],
+        },
+      },
+      {
+        id: 'admin',
+        type: 'line',
+        source: 'outdoors',
+        'source-layer': 'admin',
+        paint: {
+          'line-color': '#2b3340',
+          'line-width': ['interpolate', ['linear'], ['zoom'], 4, 0.4, 10, 1],
+          'line-dasharray': [3, 2],
+          'line-opacity': 0.6,
+        },
+      },
+    ],
+  };
 }


### PR DESCRIPTION
There is no ready-made dark Outdoors style.json (the /styles/outdoors endpoint 404s), so author the dark theme directly against Thunderforest's outdoors-v2 vector tileset instead of fetching and recolouring a style. Loads the vector source via its TileJSON and draws dark land/water, subtle hillshade relief and contours, roads/paths, and the signed cycling, mountain-biking and hiking routes. Labels are omitted to keep the small mini-map legible. Removes the failing style.json fetch and recolour code.