### PR TITLE
Refactor podium map to use anchor element as container

### DIFF
--- a/client/src/app/ride/podium-elevation-chart.component.css
+++ b/client/src/app/ride/podium-elevation-chart.component.css
@@ -3,6 +3,7 @@
 }
 
 .podium-elevation {
-  height: 120px;
+  height: 140px;
   width: 100%;
+  overflow: hidden;
 }

--- a/client/src/app/ride/podium-route-map.component.css
+++ b/client/src/app/ride/podium-route-map.component.css
@@ -2,8 +2,10 @@
   display: block;
 }
 
-.podium-map-wrap {
-  position: relative;
+.podium-map-link {
+  display: block;
+  text-decoration: none;
+  cursor: pointer;
 }
 
 .podium-map {
@@ -11,30 +13,4 @@
   width: 100%;
   border-radius: 0.5rem;
   overflow: hidden;
-}
-
-.podium-map-link {
-  position: absolute;
-  top: 0.5rem;
-  right: 0.5rem;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2rem;
-  height: 2rem;
-  border-radius: 0.5rem;
-  color: #e6edf3;
-  background: rgba(14, 17, 22, 0.78);
-  border: 1px solid rgba(230, 237, 243, 0.18);
-  text-decoration: none;
-}
-
-.podium-map-link:hover {
-  background: rgba(14, 17, 22, 0.92);
-}
-
-.podium-map-link mat-icon {
-  font-size: 1.125rem;
-  width: 1.125rem;
-  height: 1.125rem;
 }

--- a/client/src/app/ride/podium-route-map.component.html
+++ b/client/src/app/ride/podium-route-map.component.html
@@ -1,18 +1,15 @@
-<div class="podium-map-wrap">
+<a
+  class="podium-map-link"
+  data-testid="podium-map-link"
+  [href]="externalMapUrl()"
+  target="_blank"
+  rel="noopener noreferrer"
+  aria-label="Open segment in geojson.io"
+>
   <div
     #mapContainer
     class="podium-map"
     data-testid="podium-map"
     aria-label="Segment route mini map"
   ></div>
-  <a
-    class="podium-map-link"
-    data-testid="podium-map-link"
-    [href]="externalMapUrl()"
-    target="_blank"
-    rel="noopener noreferrer"
-    aria-label="Open segment in geojson.io"
-  >
-    <mat-icon aria-hidden="true">open_in_new</mat-icon>
-  </a>
-</div>
+</a>

--- a/client/src/app/ride/podium-route-map.component.ts
+++ b/client/src/app/ride/podium-route-map.component.ts
@@ -9,7 +9,6 @@ import {
   input,
   viewChild,
 } from '@angular/core';
-import { MatIconModule } from '@angular/material/icon';
 import {
   LngLatBounds,
   Map as MapLibreMap,
@@ -20,7 +19,6 @@ import { ENVIRONMENT_CONFIG } from '../environment/environment.config';
 @Component({
   standalone: true,
   selector: 'app-podium-route-map',
-  imports: [MatIconModule],
   templateUrl: './podium-route-map.component.html',
   styleUrl: './podium-route-map.component.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -57,8 +55,7 @@ export class PodiumRouteMapComponent implements AfterViewInit, OnDestroy {
     this.map = new MapLibreMap({
       container: this.container().nativeElement,
       style: darkOutdoorsStyle(this.environment.thunderforestApiKey),
-      interactive: true,
-      scrollZoom: false,
+      interactive: false,
       attributionControl: false,
     });
 

--- a/client/src/app/ride/ride.component.css
+++ b/client/src/app/ride/ride.component.css
@@ -148,13 +148,10 @@ h2 {
 
 .podium-route {
   display: grid;
-  grid-template-columns: 1fr;
+  grid-template-columns: minmax(0, 1fr);
   gap: 12px;
 }
 
-@media screen and (width > 740px) {
-  .podium-route {
-    grid-template-columns: 2fr 1fr;
-    align-items: stretch;
-  }
+.podium-route > * {
+  min-width: 0;
 }


### PR DESCRIPTION
## Summary
Refactored the podium route map component to use an anchor element as the primary container instead of a wrapper div with an absolutely positioned link. This simplifies the DOM structure and improves accessibility by making the entire map clickable.

## Key Changes
- **HTML Structure**: Changed from a `div.podium-map-wrap` containing a map and an absolutely positioned link to using an `<a>` tag as the root container with the map as a child
- **CSS Simplification**: 
  - Removed `.podium-map-wrap` positioning styles
  - Simplified `.podium-map-link` to basic block display and link styling (removed absolute positioning and icon-specific styles)
  - Removed hover state and mat-icon sizing rules
- **Component Dependencies**: Removed `MatIconModule` import as the icon element is no longer needed
- **Map Interactivity**: Changed map configuration from `interactive: true, scrollZoom: false` to `interactive: false` to prevent unintended interactions
- **Layout Improvements**:
  - Updated `.podium-route` grid to use `minmax(0, 1fr)` for better overflow handling
  - Added `min-width: 0` to grid children to prevent content overflow
  - Removed responsive media query for two-column layout
- **Elevation Chart**: Increased height from 120px to 140px and added `overflow: hidden` for better visual consistency

## Implementation Details
The refactoring makes the entire map area a clickable link to the external map viewer, improving UX by expanding the click target and simplifying the component structure. The removal of absolute positioning and the icon element reduces CSS complexity while maintaining the same visual functionality.

https://claude.ai/code/session_01RgkrUHvBgffRD237pbgnSb