### PR TITLE
Add Twingate connection to CI/CD deployment workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -249,6 +249,11 @@ jobs:
         with:
           kubelogin-version: 'v0.2.7'
 
+      - name: Connect to Twingate
+        uses: twingate/github-action@v1
+        with:
+          service-key: ${{ secrets.TWINGATE_SERVICE_KEY }}
+
       - name: Deploy to Kubernetes
         env:
           AZURE_KEYVAULT_NAME: ${{ secrets.AZURE_KEYVAULT_NAME }}


### PR DESCRIPTION
## Summary
This change adds Twingate network access to the GitHub Actions CI/CD pipeline, enabling secure connectivity to private resources during the Kubernetes deployment process.

## Key Changes
- Added Twingate GitHub Action (`twingate/github-action@v1`) to the build workflow
- Configured Twingate authentication using the `TWINGATE_SERVICE_KEY` secret
- Positioned the Twingate connection step immediately before the Kubernetes deployment step to ensure network access is established when needed

## Implementation Details
The Twingate action is inserted in the deployment job after kubelogin authentication setup and before the actual Kubernetes deployment. This ensures that any private network resources required during deployment are accessible through the Twingate secure network tunnel.

https://claude.ai/code/session_01G9PH1Q4gui2jjQ2HSkDEEa