### PR TITLE
Fix flaky chart aria-label assertions in tests

### DIFF
--- a/test/tests/reading.spec.ts
+++ b/test/tests/reading.spec.ts
@@ -378,6 +378,9 @@ test.describe('Reading', () => {
     const library = page.getByRole('region', { name: 'Books' });
     await library.getByRole('button', { name: 'Edit Old Title' }).click();
 
+    await expect(
+      library.getByRole('heading', { name: 'Edit book' })
+    ).toBeVisible();
     await library.getByLabel('Title').fill('New Title');
     await library.getByLabel('Author').fill('New Author');
     await library.getByLabel('Total pages').fill('250');

--- a/test/tests/weight.spec.ts
+++ b/test/tests/weight.spec.ts
@@ -1,6 +1,13 @@
 import { test, expect } from '../fixtures';
 import { cleanupDb, populateOAuthClients, insertWeight } from '../utils';
 
+// Build a regex that matches the literal value anywhere in the chart's
+// aria-label. echarts redraws the SVG when the data changes, so the
+// aria-label is briefly absent mid-render; asserting with toHaveAttribute
+// (which auto-retries) avoids racing a one-shot getAttribute read.
+const chartLabel = (value: string) =>
+  new RegExp(value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+
 test.describe('Weight', () => {
   test.beforeEach(async () => {
     await cleanupDb();
@@ -50,14 +57,13 @@ test.describe('Weight', () => {
     await expect(page.getByRole('heading', { name: 'Weight' })).toBeVisible();
     const chart = page.locator('section:has-text("Weight") [role="img"]');
     await expect(chart).toHaveAttribute('aria-label', /This is a chart with type Line chart/);
-    const label = await chart.getAttribute('aria-label');
-    expect(label).toContain('89.4,');
-    expect(label).toContain('88.3,');
-    expect(label).toContain('87.7,');
-    expect(label).toContain('87.5,');
-    expect(label).toContain('87.2.');
-    expect(label).not.toContain('108.9,');
-    expect(label).not.toContain('98,');
+    await expect(chart).toHaveAttribute('aria-label', chartLabel('89.4,'));
+    await expect(chart).toHaveAttribute('aria-label', chartLabel('88.3,'));
+    await expect(chart).toHaveAttribute('aria-label', chartLabel('87.7,'));
+    await expect(chart).toHaveAttribute('aria-label', chartLabel('87.5,'));
+    await expect(chart).toHaveAttribute('aria-label', chartLabel('87.2.'));
+    await expect(chart).not.toHaveAttribute('aria-label', chartLabel('108.9,'));
+    await expect(chart).not.toHaveAttribute('aria-label', chartLabel('98,'));
   });
 
   test('should display weight diff for month', async ({ page }) => {
@@ -75,14 +81,13 @@ test.describe('Weight', () => {
     await expect(page.getByRole('heading', { name: 'Weight' })).toBeVisible();
     const chart = page.locator('section:has-text("Weight") [role="img"]');
     await expect(chart).toHaveAttribute('aria-label', /This is a chart with type Line chart/);
-    const label = await chart.getAttribute('aria-label');
-    expect(label).toContain('98,');
-    expect(label).toContain('89.4,');
-    expect(label).toContain('88.3,');
-    expect(label).toContain('87.7,');
-    expect(label).toContain('87.5,');
-    expect(label).toContain('87.2.');
-    expect(label).not.toContain('108.9,');
+    await expect(chart).toHaveAttribute('aria-label', chartLabel('98,'));
+    await expect(chart).toHaveAttribute('aria-label', chartLabel('89.4,'));
+    await expect(chart).toHaveAttribute('aria-label', chartLabel('88.3,'));
+    await expect(chart).toHaveAttribute('aria-label', chartLabel('87.7,'));
+    await expect(chart).toHaveAttribute('aria-label', chartLabel('87.5,'));
+    await expect(chart).toHaveAttribute('aria-label', chartLabel('87.2.'));
+    await expect(chart).not.toHaveAttribute('aria-label', chartLabel('108.9,'));
   });
 
   test('should display weight diff for year', async ({ page }) => {
@@ -100,14 +105,13 @@ test.describe('Weight', () => {
     await expect(page.getByRole('heading', { name: 'Weight' })).toBeVisible();
     const chart = page.locator('section:has-text("Weight") [role="img"]');
     await expect(chart).toHaveAttribute('aria-label', /This is a chart with type Line chart/);
-    const label = await chart.getAttribute('aria-label');
-    expect(label).toContain('108.9,');
-    expect(label).toContain('98,');
-    expect(label).toContain('89.4,');
-    expect(label).toContain('88.3,');
-    expect(label).toContain('87.7,');
-    expect(label).toContain('87.5,');
-    expect(label).toContain('87.2.');
+    await expect(chart).toHaveAttribute('aria-label', chartLabel('108.9,'));
+    await expect(chart).toHaveAttribute('aria-label', chartLabel('98,'));
+    await expect(chart).toHaveAttribute('aria-label', chartLabel('89.4,'));
+    await expect(chart).toHaveAttribute('aria-label', chartLabel('88.3,'));
+    await expect(chart).toHaveAttribute('aria-label', chartLabel('87.7,'));
+    await expect(chart).toHaveAttribute('aria-label', chartLabel('87.5,'));
+    await expect(chart).toHaveAttribute('aria-label', chartLabel('87.2.'));
   });
 
   test('should display weight diff for all time', async ({ page }) => {
@@ -125,14 +129,13 @@ test.describe('Weight', () => {
     await expect(page.getByRole('heading', { name: 'Weight' })).toBeVisible();
     const chart = page.locator('section:has-text("Weight") [role="img"]');
     await expect(chart).toHaveAttribute('aria-label', /This is a chart with type Line chart/);
-    const label = await chart.getAttribute('aria-label');
-    expect(label).toContain('108.9,');
-    expect(label).toContain('98,');
-    expect(label).toContain('89.4,');
-    expect(label).toContain('88.3,');
-    expect(label).toContain('87.7,');
-    expect(label).toContain('87.5,');
-    expect(label).toContain('87.2.');
+    await expect(chart).toHaveAttribute('aria-label', chartLabel('108.9,'));
+    await expect(chart).toHaveAttribute('aria-label', chartLabel('98,'));
+    await expect(chart).toHaveAttribute('aria-label', chartLabel('89.4,'));
+    await expect(chart).toHaveAttribute('aria-label', chartLabel('88.3,'));
+    await expect(chart).toHaveAttribute('aria-label', chartLabel('87.7,'));
+    await expect(chart).toHaveAttribute('aria-label', chartLabel('87.5,'));
+    await expect(chart).toHaveAttribute('aria-label', chartLabel('87.2.'));
   });
 });
 
@@ -150,10 +153,9 @@ test.describe('Weight without a measurement today', () => {
     await page.goto('/');
     const chart = page.locator('section:has-text("Weight") [role="img"]').first();
     await expect(chart).toHaveAttribute('aria-label', /This is a chart with type Line chart/);
-    const label = await chart.getAttribute('aria-label');
-    expect(label).toContain('89.4,');
-    expect(label).toContain('88.3,');
-    expect(label).toContain('87.7,');
-    expect(label).toContain('87.5');
+    await expect(chart).toHaveAttribute('aria-label', chartLabel('89.4,'));
+    await expect(chart).toHaveAttribute('aria-label', chartLabel('88.3,'));
+    await expect(chart).toHaveAttribute('aria-label', chartLabel('87.7,'));
+    await expect(chart).toHaveAttribute('aria-label', chartLabel('87.5'));
   });
 });

--- a/test/tests/weight.spec.ts
+++ b/test/tests/weight.spec.ts
@@ -1,10 +1,7 @@
 import { test, expect } from '../fixtures';
 import { cleanupDb, populateOAuthClients, insertWeight } from '../utils';
 
-// Build a regex that matches the literal value anywhere in the chart's
-// aria-label. echarts redraws the SVG when the data changes, so the
-// aria-label is briefly absent mid-render; asserting with toHaveAttribute
-// (which auto-retries) avoids racing a one-shot getAttribute read.
+// Escape value into a regex; toHaveAttribute auto-retries, avoiding a one-shot read that races echarts clearing aria-label mid-redraw.
 const chartLabel = (value: string) =>
   new RegExp(value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
 


### PR DESCRIPTION
## Summary
Refactored chart aria-label assertions to use Playwright's auto-retry mechanism, eliminating race conditions caused by ECharts SVG redraws during data updates.

## Key Changes
- Added `chartLabel()` helper function that escapes special regex characters to safely match literal values in aria-label attributes
- Replaced synchronous `getAttribute()` calls with async `toHaveAttribute()` assertions across all weight and reading tests
- Updated assertions to use the new helper for proper regex escaping of numeric values (e.g., `'89.4,'` → `/89\.4,/`)
- Added explicit visibility wait for "Edit book" heading in reading test to prevent race condition

## Implementation Details
The core issue was that ECharts redraws the SVG when data changes, briefly removing the aria-label attribute mid-render. The original approach of reading the attribute once with `getAttribute()` could race against this redraw. By using `toHaveAttribute()` with regex patterns, Playwright automatically retries the assertion until the attribute is stable, eliminating the race condition.

The `chartLabel()` helper ensures special regex characters in numeric values are properly escaped so they match literally rather than being interpreted as regex syntax.

https://claude.ai/code/session_01CQrXdAQ5g8NHxwsn47hXe6