### PR TITLE
Wait for API responses in learning path activity tests

### DIFF
--- a/test/tests/learning.spec.ts
+++ b/test/tests/learning.spec.ts
@@ -121,13 +121,24 @@ test.describe('Learning paths', () => {
     });
     await expect(activity).not.toBeChecked();
 
+    const activityResponse = () =>
+      page.waitForResponse(
+        (response) =>
+          response.url().endsWith(`/api/learning-paths/${pathId}/activity`) &&
+          response.request().method() === 'PUT'
+      );
+
+    let responsePromise = activityResponse();
     await activity.check();
+    await responsePromise;
     let rows = await getLearningPathActivityRows();
     expect(rows).toHaveLength(1);
     expect(rows[0].path_id).toBe(pathId);
     expect(rows[0].date).toBe(isoDate(0));
 
+    responsePromise = activityResponse();
     await activity.uncheck();
+    await responsePromise;
     rows = await getLearningPathActivityRows();
     expect(rows).toHaveLength(0);
   });


### PR DESCRIPTION
## Summary
Updated the learning path activity test to properly wait for API responses before asserting on the results. This ensures the test doesn't make assertions on stale data and improves test reliability.

## Key Changes
- Added `activityResponse()` helper function to wait for PUT requests to the `/api/learning-paths/{pathId}/activity` endpoint
- Wrapped both the check and uncheck operations with response promise handling to ensure API calls complete before validating the activity rows
- This prevents race conditions where assertions might run before the server has processed the activity update

## Implementation Details
The test now explicitly waits for the API response after each activity state change (check/uncheck) before querying and asserting on the learning path activity rows. This makes the test more robust and ensures it's testing the actual behavior rather than relying on timing assumptions.

https://claude.ai/code/session_01Kaacxd3WbkG1WBf2GsmpKL