### PR TITLE
Move learning progress to its own routes

### DIFF
--- a/client/src/app/app.component.html
+++ b/client/src/app/app.component.html
@@ -32,6 +32,13 @@
         ariaCurrentWhenActive="page"
         >All time</a
       >
+      <a
+        mat-button
+        routerLink="learning"
+        routerLinkActive
+        ariaCurrentWhenActive="page"
+        >Learning</a
+      >
     </div>
     <button
       type="button"
@@ -75,6 +82,13 @@
         routerLinkActive
         ariaCurrentWhenActive="page"
         >All time</a
+      >
+      <a
+        mat-menu-item
+        routerLink="learning"
+        routerLinkActive
+        ariaCurrentWhenActive="page"
+        >Learning</a
       >
     </mat-menu>
     <div class="header-right">

--- a/client/src/app/app.config.ts
+++ b/client/src/app/app.config.ts
@@ -5,7 +5,7 @@ import {
   provideAppInitializer,
   provideZoneChangeDetection,
 } from '@angular/core';
-import { provideRouter } from '@angular/router';
+import { provideRouter, withComponentInputBinding } from '@angular/router';
 
 import {
   provideHttpClient,
@@ -46,7 +46,7 @@ export function getAppConfig(environment: EnvironmentConfig): ApplicationConfig 
   return {
     providers: [
       provideZoneChangeDetection({ eventCoalescing: true }),
-      provideRouter(routes),
+      provideRouter(routes, withComponentInputBinding()),
       provideHttpClient(
         withInterceptors([
           errorInterceptor,

--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -31,6 +31,21 @@ export const routes: Routes = [
     canActivate: [authGuard],
   },
   {
+    path: 'learning',
+    loadComponent: () =>
+      import('./learning/learning.component').then((m) => m.LearningComponent),
+    pathMatch: 'full',
+    canActivate: [authGuard],
+  },
+  {
+    path: 'learning/:id',
+    loadComponent: () =>
+      import('./learning/learning-path.component').then(
+        (m) => m.LearningPathComponent
+      ),
+    canActivate: [authGuard],
+  },
+  {
     path: 'settings',
     loadComponent: () =>
       import('./settings/settings.component').then((m) => m.SettingsComponent),

--- a/client/src/app/home/home.component.html
+++ b/client/src/app/home/home.component.html
@@ -2,7 +2,7 @@
 <app-daily-tasks></app-daily-tasks>
 <app-pushups></app-pushups>
 <app-reading></app-reading>
-<app-learning></app-learning>
+<app-learning-summary></app-learning-summary>
 <app-ride></app-ride>
 <app-fitness></app-fitness>
 <app-ftp></app-ftp>

--- a/client/src/app/home/home.component.ts
+++ b/client/src/app/home/home.component.ts
@@ -7,7 +7,7 @@ import { PushupsComponent } from '../pushups/pushups.component';
 import { ReadingComponent } from '../reading/reading.component';
 import { GoldenDayComponent } from '../golden-day/golden-day.component';
 import { DailyTasksComponent } from '../daily-tasks/daily-tasks.component';
-import { LearningComponent } from '../learning/learning.component';
+import { LearningSummaryComponent } from '../learning/learning-summary.component';
 
 @Component({
   selector: 'app-home',
@@ -21,7 +21,7 @@ import { LearningComponent } from '../learning/learning.component';
     FtpComponent,
     PushupsComponent,
     ReadingComponent,
-    LearningComponent,
+    LearningSummaryComponent,
   ],
   templateUrl: './home.component.html',
   styleUrl: './home.component.css',

--- a/client/src/app/learning/learning-path.component.css
+++ b/client/src/app/learning/learning-path.component.css
@@ -1,0 +1,90 @@
+.learning-path {
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, hsl(217, 28%, 18%), hsl(217, 28%, 14%));
+  border: 1px solid hsl(217, 19%, 27%);
+}
+
+.back {
+  justify-self: start;
+  font-size: 13px;
+  color: var(--bt-text-muted);
+}
+
+.path-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.path-title {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--mat-sys-on-primary);
+}
+
+.path-progress {
+  margin: 0;
+  font-size: 13px;
+  color: var(--bt-text-muted);
+  white-space: nowrap;
+}
+
+.path-summary {
+  margin: 0;
+  font-size: 14px;
+  color: var(--bt-text-muted);
+}
+
+.topic {
+  display: grid;
+  gap: 4px;
+  padding: 12px;
+  border-radius: 12px;
+  background: hsl(217, 28%, 16%);
+  border: 1px solid hsl(217, 19%, 24%);
+}
+
+.topic-title {
+  margin: 0 0 4px;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--mat-sys-on-primary);
+}
+
+.blocks {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.block {
+  display: grid;
+  gap: 2px;
+}
+
+.block-main {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.block-icon {
+  flex: none;
+  color: var(--bt-text-muted);
+  font-size: 18px;
+  width: 18px;
+  height: 18px;
+}
+
+.block-description {
+  margin-left: 34px;
+  color: var(--bt-text-muted);
+  font-size: 12px;
+}

--- a/client/src/app/learning/learning-path.component.html
+++ b/client/src/app/learning/learning-path.component.html
@@ -1,0 +1,49 @@
+@if (path.isLoading()) {
+  <div class="page-loading"><bt-bar-loader /></div>
+} @else if (path.value(); as path) {
+  <section class="learning-path" aria-labelledby="learning-path-heading">
+    <a class="back" routerLink="/learning">&larr; All learning paths</a>
+    <header class="path-header">
+      <h1 id="learning-path-heading" class="path-title">{{ path.title }}</h1>
+      <p class="path-progress">
+        {{ progressDone(path) }} / {{ progressTotal(path) }} done
+      </p>
+    </header>
+    <p class="path-summary">{{ path.content.summary }}</p>
+
+    @for (topic of path.content.topics; track topic.id) {
+      <div class="topic">
+        <h2 class="topic-title">{{ topic.title }}</h2>
+        <ul class="blocks">
+          @for (block of topic.blocks; track block.id) {
+            <li class="block">
+              <mat-checkbox
+                [checked]="!!block.completed"
+                [disabled]="togglingBlockId() !== null"
+                (change)="toggleBlock(path, block.id, $event.checked)"
+              >
+                <span class="block-main">
+                  <mat-icon class="block-icon" aria-hidden="true">{{ blockIcon(block.type) }}</mat-icon>
+                  @if (block.url) {
+                    <a
+                      [href]="block.url"
+                      target="_blank"
+                      rel="noopener"
+                      (click)="$event.stopPropagation()"
+                      >{{ block.title }}</a
+                    >
+                  } @else {
+                    <span>{{ block.title }}</span>
+                  }
+                </span>
+              </mat-checkbox>
+              @if (block.description) {
+                <span class="block-description">{{ block.description }}</span>
+              }
+            </li>
+          }
+        </ul>
+      </div>
+    }
+  </section>
+}

--- a/client/src/app/learning/learning-path.component.ts
+++ b/client/src/app/learning/learning-path.component.ts
@@ -1,0 +1,54 @@
+import { Component, computed, inject, input, resource, signal } from '@angular/core';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatIconModule } from '@angular/material/icon';
+import { RouterLink } from '@angular/router';
+import { BarLoaderComponent } from '@mucsi96/angular-material-theme';
+import { LearningPath, LearningPathService } from './learning-path.service';
+import { blockIcon } from './block-icon';
+
+@Component({
+  standalone: true,
+  selector: 'app-learning-path',
+  imports: [MatCheckboxModule, MatIconModule, RouterLink, BarLoaderComponent],
+  templateUrl: './learning-path.component.html',
+  styleUrl: './learning-path.component.css',
+})
+export class LearningPathComponent {
+  private readonly service = inject(LearningPathService);
+
+  readonly id = input.required<string>();
+
+  readonly togglingBlockId = signal<string | null>(null);
+
+  readonly path = resource({
+    params: () => ({ id: this.id(), version: this.service.version() }),
+    loader: ({ params }) => this.service.getPath(params.id),
+  });
+
+  readonly blockIcon = blockIcon;
+
+  progressDone(path: LearningPath): number {
+    return path.content.topics
+      .flatMap((topic) => topic.blocks)
+      .filter((block) => block.completed).length;
+  }
+
+  progressTotal(path: LearningPath): number {
+    return path.content.topics.reduce(
+      (total, topic) => total + topic.blocks.length,
+      0
+    );
+  }
+
+  async toggleBlock(path: LearningPath, blockId: string, completed: boolean) {
+    if (this.togglingBlockId() !== null) {
+      return;
+    }
+    this.togglingBlockId.set(blockId);
+    try {
+      await this.service.setBlockCompleted(path.id, blockId, completed);
+    } finally {
+      this.togglingBlockId.set(null);
+    }
+  }
+}

--- a/client/src/app/learning/learning-path.service.ts
+++ b/client/src/app/learning/learning-path.service.ts
@@ -53,6 +53,18 @@ export class LearningPathService {
     }
   }
 
+  async getPath(id: string): Promise<LearningPath> {
+    try {
+      return await fetchJson<LearningPath>(
+        this.http,
+        `/api/learning-paths/${id}`
+      );
+    } catch (e) {
+      this.notifications.error('Unable to load learning path');
+      throw e;
+    }
+  }
+
   async getToday(): Promise<LearningPathStatus[]> {
     try {
       return await fetchJson<LearningPathStatus[]>(

--- a/client/src/app/learning/learning-summary.component.css
+++ b/client/src/app/learning/learning-summary.component.css
@@ -1,0 +1,80 @@
+.learning {
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, hsl(217, 28%, 18%), hsl(217, 28%, 14%));
+  border: 1px solid hsl(217, 19%, 27%);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+h2 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--mat-sys-on-primary);
+}
+
+.view-all {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  font-size: 13px;
+  color: var(--bt-text-muted);
+  text-decoration: none;
+}
+
+.view-all mat-icon {
+  font-size: 18px;
+  width: 18px;
+  height: 18px;
+}
+
+.paths {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.path {
+  display: grid;
+  gap: 4px;
+  padding: 12px;
+  border-radius: 12px;
+  background: hsl(217, 28%, 16%);
+  border: 1px solid hsl(217, 19%, 24%);
+}
+
+.path-link {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  color: inherit;
+  text-decoration: none;
+}
+
+.path-link:hover .path-title {
+  text-decoration: underline;
+}
+
+.path-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--mat-sys-on-primary);
+}
+
+.path-progress {
+  font-size: 12px;
+  color: var(--bt-text-muted);
+  white-space: nowrap;
+}

--- a/client/src/app/learning/learning-summary.component.html
+++ b/client/src/app/learning/learning-summary.component.html
@@ -1,0 +1,31 @@
+@if (paths.isLoading()) {
+  <div class="page-loading"><bt-bar-loader /></div>
+} @else if (hasPaths()) {
+  <section class="learning" aria-labelledby="learning-summary-heading">
+    <header class="header">
+      <h2 id="learning-summary-heading">Learning</h2>
+      <a class="view-all" routerLink="/learning">
+        View all <mat-icon aria-hidden="true">chevron_right</mat-icon>
+      </a>
+    </header>
+    <ul class="paths">
+      @for (path of paths.value(); track path.id) {
+        <li class="path" [attr.aria-label]="path.title">
+          <a class="path-link" [routerLink]="['/learning', path.id]">
+            <span class="path-title">{{ path.title }}</span>
+            <span class="path-progress">
+              {{ progressDone(path) }} / {{ progressTotal(path) }} done
+            </span>
+          </a>
+          <mat-checkbox
+            [checked]="isActive(path.id)"
+            [disabled]="togglingActivityId() !== null"
+            (change)="toggleActivity(path, $event.checked)"
+          >
+            I did something for this today
+          </mat-checkbox>
+        </li>
+      }
+    </ul>
+  </section>
+}

--- a/client/src/app/learning/learning-summary.component.ts
+++ b/client/src/app/learning/learning-summary.component.ts
@@ -1,0 +1,69 @@
+import { Component, computed, inject, resource, signal } from '@angular/core';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatIconModule } from '@angular/material/icon';
+import { RouterLink } from '@angular/router';
+import { BarLoaderComponent } from '@mucsi96/angular-material-theme';
+import { LearningPath, LearningPathService } from './learning-path.service';
+
+@Component({
+  standalone: true,
+  selector: 'app-learning-summary',
+  imports: [MatCheckboxModule, MatIconModule, RouterLink, BarLoaderComponent],
+  templateUrl: './learning-summary.component.html',
+  styleUrl: './learning-summary.component.css',
+})
+export class LearningSummaryComponent {
+  private readonly service = inject(LearningPathService);
+
+  readonly togglingActivityId = signal<string | null>(null);
+
+  readonly paths = resource({
+    params: () => this.service.version(),
+    loader: () => this.service.getPaths(),
+  });
+
+  readonly today = resource({
+    params: () => this.service.version(),
+    loader: () => this.service.getToday(),
+  });
+
+  readonly hasPaths = computed(() => (this.paths.value()?.length ?? 0) > 0);
+
+  readonly activeIds = computed(
+    () =>
+      new Set(
+        (this.today.value() ?? [])
+          .filter((path) => path.active)
+          .map((path) => path.id)
+      )
+  );
+
+  isActive(id: string): boolean {
+    return this.activeIds().has(id);
+  }
+
+  progressDone(path: LearningPath): number {
+    return path.content.topics
+      .flatMap((topic) => topic.blocks)
+      .filter((block) => block.completed).length;
+  }
+
+  progressTotal(path: LearningPath): number {
+    return path.content.topics.reduce(
+      (total, topic) => total + topic.blocks.length,
+      0
+    );
+  }
+
+  async toggleActivity(path: LearningPath, active: boolean) {
+    if (this.togglingActivityId() !== null) {
+      return;
+    }
+    this.togglingActivityId.set(path.id);
+    try {
+      await this.service.setActivity(path.id, active);
+    } finally {
+      this.togglingActivityId.set(null);
+    }
+  }
+}

--- a/client/src/app/learning/learning.component.css
+++ b/client/src/app/learning/learning.component.css
@@ -1,10 +1,6 @@
 .learning {
   display: grid;
   gap: 12px;
-  padding: 16px;
-  border-radius: 14px;
-  background: linear-gradient(135deg, hsl(217, 28%, 18%), hsl(217, 28%, 14%));
-  border: 1px solid hsl(217, 19%, 27%);
 }
 
 .header {
@@ -13,13 +9,17 @@
   justify-content: space-between;
 }
 
-h2 {
+h1 {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 600;
+  color: var(--mat-sys-on-primary);
+}
+
+.empty {
   margin: 0;
   font-size: 14px;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: var(--mat-sys-on-primary);
+  color: var(--bt-text-muted);
 }
 
 .paths {
@@ -30,13 +30,20 @@ h2 {
   gap: 12px;
 }
 
-.path {
+.path-link {
   display: grid;
   gap: 8px;
-  padding: 12px;
-  border-radius: 12px;
-  background: hsl(217, 28%, 16%);
-  border: 1px solid hsl(217, 19%, 24%);
+  padding: 16px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, hsl(217, 28%, 18%), hsl(217, 28%, 14%));
+  border: 1px solid hsl(217, 19%, 27%);
+  color: inherit;
+  text-decoration: none;
+  transition: border-color 0.2s ease;
+}
+
+.path-link:hover {
+  border-color: var(--mat-sys-primary);
 }
 
 .path-header {
@@ -48,7 +55,7 @@ h2 {
 
 .path-title {
   margin: 0;
-  font-size: 15px;
+  font-size: 16px;
   font-weight: 600;
   color: var(--mat-sys-on-primary);
 }
@@ -57,61 +64,11 @@ h2 {
   margin: 0;
   font-size: 12px;
   color: var(--bt-text-muted);
+  white-space: nowrap;
 }
 
 .path-summary {
   margin: 0;
   font-size: 13px;
   color: var(--bt-text-muted);
-}
-
-.topic {
-  display: grid;
-  gap: 4px;
-}
-
-.topic-title {
-  margin: 4px 0 0;
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--mat-sys-on-primary);
-}
-
-.blocks {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  gap: 2px;
-}
-
-.block {
-  display: grid;
-  gap: 2px;
-}
-
-.block-main {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.block-icon {
-  flex: none;
-  color: var(--bt-text-muted);
-  font-size: 18px;
-  width: 18px;
-  height: 18px;
-}
-
-.block-description {
-  margin-left: 34px;
-  color: var(--bt-text-muted);
-  font-size: 12px;
-}
-
-.path-activity {
-  margin-top: 4px;
-  padding-top: 8px;
-  border-top: 1px solid hsl(217, 19%, 24%);
 }

--- a/client/src/app/learning/learning.component.html
+++ b/client/src/app/learning/learning.component.html
@@ -1,67 +1,32 @@
 @if (paths.isLoading()) {
   <div class="page-loading"><bt-bar-loader /></div>
-} @else if (hasPaths()) {
+} @else {
   <section class="learning" aria-labelledby="learning-heading">
     <header class="header">
-      <h2 id="learning-heading">Learning</h2>
+      <h1 id="learning-heading">Learning</h1>
     </header>
-    <ul class="paths">
-      @for (path of paths.value(); track path.id) {
-        <li class="path" [attr.aria-label]="path.title">
-          <header class="path-header">
-            <h3 class="path-title">{{ path.title }}</h3>
-            <p class="path-progress">
-              {{ progressDone(path) }} / {{ progressTotal(path) }} done
-            </p>
-          </header>
-          <p class="path-summary">{{ path.content.summary }}</p>
 
-          @for (topic of path.content.topics; track topic.id) {
-            <div class="topic">
-              <h4 class="topic-title">{{ topic.title }}</h4>
-              <ul class="blocks">
-                @for (block of topic.blocks; track block.id) {
-                  <li class="block">
-                    <mat-checkbox
-                      [checked]="!!block.completed"
-                      [disabled]="togglingBlockId() !== null"
-                      (change)="toggleBlock(path, block.id, $event.checked)"
-                    >
-                      <span class="block-main">
-                        <mat-icon class="block-icon" aria-hidden="true">{{ blockIcon(block.type) }}</mat-icon>
-                        @if (block.url) {
-                          <a
-                            [href]="block.url"
-                            target="_blank"
-                            rel="noopener"
-                            (click)="$event.stopPropagation()"
-                            >{{ block.title }}</a
-                          >
-                        } @else {
-                          <span>{{ block.title }}</span>
-                        }
-                      </span>
-                    </mat-checkbox>
-                    @if (block.description) {
-                      <span class="block-description">{{ block.description }}</span>
-                    }
-                  </li>
-                }
-              </ul>
-            </div>
-          }
-
-          <div class="path-activity">
-            <mat-checkbox
-              [checked]="isActive(path.id)"
-              [disabled]="togglingActivityId() !== null"
-              (change)="toggleActivity(path, $event.checked)"
-            >
-              I did something for this today
-            </mat-checkbox>
-          </div>
-        </li>
-      }
-    </ul>
+    @if ((paths.value()?.length ?? 0) === 0) {
+      <p class="empty">
+        No learning paths yet. Add one from
+        <a routerLink="/settings">settings</a>.
+      </p>
+    } @else {
+      <ul class="paths">
+        @for (path of paths.value(); track path.id) {
+          <li class="path">
+            <a class="path-link" [routerLink]="['/learning', path.id]" [attr.aria-label]="path.title">
+              <header class="path-header">
+                <h2 class="path-title">{{ path.title }}</h2>
+                <p class="path-progress">
+                  {{ progressDone(path) }} / {{ progressTotal(path) }} done
+                </p>
+              </header>
+              <p class="path-summary">{{ path.content.summary }}</p>
+            </a>
+          </li>
+        }
+      </ul>
+    }
   </section>
 }

--- a/client/src/app/learning/learning.component.ts
+++ b/client/src/app/learning/learning.component.ts
@@ -1,49 +1,22 @@
-import { Component, computed, inject, resource, signal } from '@angular/core';
-import { MatCheckboxModule } from '@angular/material/checkbox';
-import { MatIconModule } from '@angular/material/icon';
+import { Component, inject, resource } from '@angular/core';
+import { RouterLink } from '@angular/router';
 import { BarLoaderComponent } from '@mucsi96/angular-material-theme';
 import { LearningPath, LearningPathService } from './learning-path.service';
-import { blockIcon } from './block-icon';
 
 @Component({
   standalone: true,
   selector: 'app-learning',
-  imports: [MatCheckboxModule, MatIconModule, BarLoaderComponent],
+  imports: [RouterLink, BarLoaderComponent],
   templateUrl: './learning.component.html',
   styleUrl: './learning.component.css',
 })
 export class LearningComponent {
   private readonly service = inject(LearningPathService);
 
-  readonly togglingBlockId = signal<string | null>(null);
-  readonly togglingActivityId = signal<string | null>(null);
-
   readonly paths = resource({
     params: () => this.service.version(),
     loader: () => this.service.getPaths(),
   });
-
-  readonly today = resource({
-    params: () => this.service.version(),
-    loader: () => this.service.getToday(),
-  });
-
-  readonly hasPaths = computed(() => (this.paths.value()?.length ?? 0) > 0);
-
-  readonly activeIds = computed(
-    () =>
-      new Set(
-        (this.today.value() ?? [])
-          .filter((path) => path.active)
-          .map((path) => path.id)
-      )
-  );
-
-  readonly blockIcon = blockIcon;
-
-  isActive(id: string): boolean {
-    return this.activeIds().has(id);
-  }
 
   progressDone(path: LearningPath): number {
     return path.content.topics
@@ -56,29 +29,5 @@ export class LearningComponent {
       (total, topic) => total + topic.blocks.length,
       0
     );
-  }
-
-  async toggleBlock(path: LearningPath, blockId: string, completed: boolean) {
-    if (this.togglingBlockId() !== null) {
-      return;
-    }
-    this.togglingBlockId.set(blockId);
-    try {
-      await this.service.setBlockCompleted(path.id, blockId, completed);
-    } finally {
-      this.togglingBlockId.set(null);
-    }
-  }
-
-  async toggleActivity(path: LearningPath, active: boolean) {
-    if (this.togglingActivityId() !== null) {
-      return;
-    }
-    this.togglingActivityId.set(path.id);
-    try {
-      await this.service.setActivity(path.id, active);
-    } finally {
-      this.togglingActivityId.set(null);
-    }
   }
 }

--- a/test/tests/learning.spec.ts
+++ b/test/tests/learning.spec.ts
@@ -79,7 +79,44 @@ test.describe('Learning paths', () => {
     expect(rows[0].content.summary).toBe('A deeper path with advanced material.');
   });
 
-  test('shows a saved path on the home page and toggles block progress', async ({ page }) => {
+  test('summarizes a saved path on home and links to its own page', async ({ page }) => {
+    const pathId = randomUUID();
+    await insertLearningPath(pathId, 'My Path', minimalContent('Intro video'));
+
+    await page.goto('/');
+    const summary = page.getByRole('region', { name: 'Learning' });
+    const link = summary.getByRole('link', { name: 'My Path' });
+    await expect(link).toBeVisible();
+    await expect(summary.getByText('0 / 1 done')).toBeVisible();
+
+    await link.click();
+    await expect(page).toHaveURL(`/learning/${pathId}`);
+    await expect(
+      page.getByRole('heading', { level: 1, name: 'My Path' })
+    ).toBeVisible();
+  });
+
+  test('lists learning paths on the learning page', async ({ page }) => {
+    const pathId = randomUUID();
+    await insertLearningPath(pathId, 'My Path', minimalContent('Intro video'));
+
+    await page.goto('/learning');
+    const overview = page.getByRole('region', { name: 'Learning' });
+    const link = overview.getByRole('link', { name: 'My Path' });
+    await expect(link).toBeVisible();
+    await expect(overview.getByText('0 / 1 done')).toBeVisible();
+
+    await link.click();
+    await expect(page).toHaveURL(`/learning/${pathId}`);
+  });
+
+  test('shows an empty state on the learning page when no paths exist', async ({ page }) => {
+    await page.goto('/learning');
+    const overview = page.getByRole('region', { name: 'Learning' });
+    await expect(overview.getByText('No learning paths yet.')).toBeVisible();
+  });
+
+  test('toggles block progress on a learning path page', async ({ page }) => {
     const pathId = randomUUID();
     const blockId = randomUUID();
     const content = {
@@ -96,9 +133,9 @@ test.describe('Learning paths', () => {
     };
     await insertLearningPath(pathId, 'My Path', content);
 
-    await page.goto('/');
-    const section = page.getByRole('region', { name: 'Learning' });
-    await expect(section.getByRole('heading', { name: 'My Path' })).toBeVisible();
+    await page.goto(`/learning/${pathId}`);
+    const section = page.getByRole('region', { name: 'My Path' });
+    await expect(section.getByRole('heading', { level: 1, name: 'My Path' })).toBeVisible();
     await expect(section.getByText('0 / 1 done')).toBeVisible();
 
     const checkbox = section.getByRole('checkbox', { name: 'Read this' });


### PR DESCRIPTION
The learning progress card had grown significant on the home page, so
split it into dedicated routes:

- /learning lists every learning path as a card linking to its own page
- /learning/:id shows a single path with its topic/block-level progress
- Home keeps a compact summary card with the daily activity toggle and
  links into the learning pages
- Add a Learning entry to the top navigation

Enable router component input binding to bind the :id route param.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JnyCzgU6diTqhDiNWbSaDg