### PR TITLE
Add progress logging to learning paths

### DIFF
--- a/client/src/app/learning/learning-path-progress-dialog.component.css
+++ b/client/src/app/learning/learning-path-progress-dialog.component.css
@@ -1,0 +1,21 @@
+.dialog-content {
+  display: grid;
+  gap: 8px;
+  padding-top: 8px;
+  min-width: 320px;
+}
+
+.path-title {
+  margin: 0;
+  color: var(--bt-text-muted);
+  font-size: 13px;
+}
+
+.progress-form {
+  display: grid;
+  gap: 8px;
+}
+
+.progress-form mat-form-field {
+  width: 100%;
+}

--- a/client/src/app/learning/learning-path-progress-dialog.component.html
+++ b/client/src/app/learning/learning-path-progress-dialog.component.html
@@ -1,0 +1,50 @@
+<h2 mat-dialog-title>Log progress</h2>
+<mat-dialog-content class="dialog-content">
+  <p class="path-title">{{ data.title }}</p>
+  <form class="progress-form" (submit)="save(); $event.preventDefault()">
+    <mat-form-field appearance="outline">
+      <mat-label>Time spent (minutes)</mat-label>
+      <input
+        matInput
+        type="number"
+        name="durationMinutes"
+        min="1"
+        [ngModel]="durationMinutes()"
+        (ngModelChange)="durationMinutes.set($event)"
+        required
+      />
+    </mat-form-field>
+    <mat-form-field appearance="outline">
+      <mat-label>What did you do?</mat-label>
+      <input
+        matInput
+        name="description"
+        [ngModel]="description()"
+        (ngModelChange)="description.set($event)"
+        required
+      />
+    </mat-form-field>
+    <mat-form-field appearance="outline">
+      <mat-label>Where did you reach?</mat-label>
+      <textarea
+        matInput
+        name="comment"
+        rows="3"
+        [ngModel]="comment()"
+        (ngModelChange)="comment.set($event)"
+      ></textarea>
+    </mat-form-field>
+  </form>
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-button type="button" (click)="cancel()">Cancel</button>
+  <button
+    mat-flat-button
+    color="primary"
+    type="button"
+    [disabled]="!canSave()"
+    (click)="save()"
+  >
+    Save
+  </button>
+</mat-dialog-actions>

--- a/client/src/app/learning/learning-path-progress-dialog.component.ts
+++ b/client/src/app/learning/learning-path-progress-dialog.component.ts
@@ -1,0 +1,76 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogModule,
+  MatDialogRef,
+} from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+
+export type LearningPathProgressDialogData = {
+  title: string;
+};
+
+export type LearningPathProgressDialogResult = {
+  durationMinutes: number;
+  description: string;
+  comment?: string;
+} | null;
+
+@Component({
+  standalone: true,
+  selector: 'app-learning-path-progress-dialog',
+  imports: [
+    FormsModule,
+    MatButtonModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatInputModule,
+  ],
+  templateUrl: './learning-path-progress-dialog.component.html',
+  styleUrl: './learning-path-progress-dialog.component.css',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class LearningPathProgressDialogComponent {
+  private readonly dialogRef = inject<
+    MatDialogRef<
+      LearningPathProgressDialogComponent,
+      LearningPathProgressDialogResult
+    >
+  >(MatDialogRef);
+  readonly data = inject<LearningPathProgressDialogData>(MAT_DIALOG_DATA);
+
+  readonly durationMinutes = signal<number | null>(null);
+  readonly description = signal('');
+  readonly comment = signal('');
+
+  readonly canSave = computed(
+    () =>
+      (this.durationMinutes() ?? 0) > 0 &&
+      this.description().trim().length > 0
+  );
+
+  cancel(): void {
+    this.dialogRef.close(null);
+  }
+
+  save(): void {
+    if (!this.canSave()) {
+      return;
+    }
+    const comment = this.comment().trim();
+    this.dialogRef.close({
+      durationMinutes: this.durationMinutes()!,
+      description: this.description().trim(),
+      comment: comment.length > 0 ? comment : undefined,
+    });
+  }
+}

--- a/client/src/app/learning/learning-path.component.css
+++ b/client/src/app/learning/learning-path.component.css
@@ -88,3 +88,87 @@
   color: var(--bt-text-muted);
   font-size: 12px;
 }
+
+.continue-banner {
+  display: grid;
+  gap: 4px;
+  padding: 12px;
+  border-radius: 12px;
+  background: hsl(150, 30%, 16%);
+  border: 1px solid hsl(150, 25%, 30%);
+}
+
+.continue-title {
+  margin: 0;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--bt-text-muted);
+}
+
+.continue-comment {
+  margin: 0;
+  font-size: 14px;
+  color: var(--mat-sys-on-primary);
+  white-space: pre-wrap;
+}
+
+.log-button {
+  justify-self: start;
+}
+
+.progress-log {
+  display: grid;
+  gap: 8px;
+}
+
+.progress-log-title {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--mat-sys-on-primary);
+}
+
+.progress-entries {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.progress-entry {
+  display: grid;
+  gap: 4px;
+  padding: 12px;
+  border-radius: 12px;
+  background: hsl(217, 28%, 16%);
+  border: 1px solid hsl(217, 19%, 24%);
+}
+
+.entry-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.entry-description {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--mat-sys-on-primary);
+}
+
+.entry-meta {
+  font-size: 12px;
+  color: var(--bt-text-muted);
+  white-space: nowrap;
+}
+
+.entry-comment {
+  margin: 0;
+  font-size: 13px;
+  color: var(--bt-text-muted);
+  white-space: pre-wrap;
+}

--- a/client/src/app/learning/learning-path.component.html
+++ b/client/src/app/learning/learning-path.component.html
@@ -11,6 +11,26 @@
     </header>
     <p class="path-summary">{{ path.content.summary }}</p>
 
+    @if (latestProgress(); as latest) {
+      @if (latest.comment) {
+        <section class="continue-banner" aria-labelledby="continue-heading">
+          <h2 id="continue-heading" class="continue-title">Continue from</h2>
+          <p class="continue-comment">{{ latest.comment }}</p>
+        </section>
+      }
+    }
+
+    <button
+      mat-flat-button
+      color="primary"
+      type="button"
+      class="log-button"
+      [disabled]="logging()"
+      (click)="openLogDialog(path)"
+    >
+      Log progress
+    </button>
+
     @for (topic of path.content.topics; track topic.id) {
       <div class="topic">
         <h2 class="topic-title">{{ topic.title }}</h2>
@@ -44,6 +64,28 @@
           }
         </ul>
       </div>
+    }
+
+    @if ((progress.value()?.length ?? 0) > 0) {
+      <section class="progress-log" aria-labelledby="progress-log-heading">
+        <h2 id="progress-log-heading" class="progress-log-title">Progress log</h2>
+        <ul class="progress-entries">
+          @for (entry of progress.value(); track entry.id) {
+            <li class="progress-entry">
+              <div class="entry-header">
+                <span class="entry-description">{{ entry.description }}</span>
+                <span class="entry-meta">
+                  {{ entry.durationMinutes }} min &middot;
+                  {{ entry.createdAt | date: 'mediumDate' }}
+                </span>
+              </div>
+              @if (entry.comment) {
+                <p class="entry-comment">{{ entry.comment }}</p>
+              }
+            </li>
+          }
+        </ul>
+      </section>
     }
   </section>
 }

--- a/client/src/app/learning/learning-path.component.ts
+++ b/client/src/app/learning/learning-path.component.ts
@@ -1,29 +1,55 @@
+import { DatePipe } from '@angular/common';
 import { Component, computed, inject, input, resource, signal } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatDialog } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
 import { RouterLink } from '@angular/router';
 import { BarLoaderComponent } from '@mucsi96/angular-material-theme';
-import { LearningPath, LearningPathService } from './learning-path.service';
+import {
+  LearningPath,
+  LearningPathService,
+} from './learning-path.service';
+import {
+  LearningPathProgressDialogComponent,
+  LearningPathProgressDialogResult,
+} from './learning-path-progress-dialog.component';
 import { blockIcon } from './block-icon';
 
 @Component({
   standalone: true,
   selector: 'app-learning-path',
-  imports: [MatCheckboxModule, MatIconModule, RouterLink, BarLoaderComponent],
+  imports: [
+    DatePipe,
+    MatButtonModule,
+    MatCheckboxModule,
+    MatIconModule,
+    RouterLink,
+    BarLoaderComponent,
+  ],
   templateUrl: './learning-path.component.html',
   styleUrl: './learning-path.component.css',
 })
 export class LearningPathComponent {
   private readonly service = inject(LearningPathService);
+  private readonly dialog = inject(MatDialog);
 
   readonly id = input.required<string>();
 
   readonly togglingBlockId = signal<string | null>(null);
+  readonly logging = signal(false);
 
   readonly path = resource({
     params: () => ({ id: this.id(), version: this.service.version() }),
     loader: ({ params }) => this.service.getPath(params.id),
   });
+
+  readonly progress = resource({
+    params: () => ({ id: this.id(), version: this.service.version() }),
+    loader: ({ params }) => this.service.getProgress(params.id),
+  });
+
+  readonly latestProgress = computed(() => this.progress.value()?.[0]);
 
   readonly blockIcon = blockIcon;
 
@@ -49,6 +75,45 @@ export class LearningPathComponent {
       await this.service.setBlockCompleted(path.id, blockId, completed);
     } finally {
       this.togglingBlockId.set(null);
+    }
+  }
+
+  openLogDialog(path: LearningPath): void {
+    if (this.logging()) {
+      return;
+    }
+    const ref = this.dialog.open<
+      LearningPathProgressDialogComponent,
+      { title: string },
+      LearningPathProgressDialogResult
+    >(LearningPathProgressDialogComponent, {
+      data: { title: path.title },
+      autoFocus: 'dialog',
+      restoreFocus: true,
+    });
+    ref.afterClosed().subscribe((result) => {
+      if (result) {
+        this.logProgress(
+          path.id,
+          result.durationMinutes,
+          result.description,
+          result.comment
+        );
+      }
+    });
+  }
+
+  private async logProgress(
+    id: string,
+    durationMinutes: number,
+    description: string,
+    comment?: string
+  ) {
+    this.logging.set(true);
+    try {
+      await this.service.logProgress(id, durationMinutes, description, comment);
+    } finally {
+      this.logging.set(false);
     }
   }
 }

--- a/client/src/app/learning/learning-path.service.ts
+++ b/client/src/app/learning/learning-path.service.ts
@@ -37,6 +37,14 @@ export type LearningPathStatus = {
   active: boolean;
 };
 
+export type LearningPathProgress = {
+  id: string;
+  createdAt: string;
+  durationMinutes: number;
+  description: string;
+  comment?: string;
+};
+
 @Injectable({ providedIn: 'root' })
 export class LearningPathService {
   private readonly http = inject(HttpClient);
@@ -157,6 +165,38 @@ export class LearningPathService {
       return path;
     } catch (e) {
       this.notifications.error('Unable to update progress');
+      throw e;
+    }
+  }
+
+  async getProgress(id: string): Promise<LearningPathProgress[]> {
+    try {
+      return await fetchJson<LearningPathProgress[]>(
+        this.http,
+        `/api/learning-paths/${id}/progress`
+      );
+    } catch (e) {
+      this.notifications.error('Unable to load progress log');
+      throw e;
+    }
+  }
+
+  async logProgress(
+    id: string,
+    durationMinutes: number,
+    description: string,
+    comment?: string
+  ): Promise<LearningPathProgress> {
+    try {
+      const entry = await fetchJson<LearningPathProgress>(
+        this.http,
+        `/api/learning-paths/${id}/progress`,
+        { method: 'post', body: { durationMinutes, description, comment } }
+      );
+      this.version.update((v) => v + 1);
+      return entry;
+    } catch (e) {
+      this.notifications.error('Unable to log progress');
       throw e;
     }
   }

--- a/server/src/main/java/mucsi96/traininglog/learning/LearningPathController.java
+++ b/server/src/main/java/mucsi96/traininglog/learning/LearningPathController.java
@@ -22,12 +22,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import mucsi96.traininglog.api.LearningPath;
 import mucsi96.traininglog.api.LearningPathContent;
+import mucsi96.traininglog.api.LearningPathProgress;
 import mucsi96.traininglog.api.LearningPathStatus;
 
 @RestController
@@ -115,6 +117,26 @@ public class LearningPathController {
     return ResponseEntity.noContent().build();
   }
 
+  @GetMapping("/{id}/progress")
+  @PreAuthorize("hasAuthority('APPROLE_WorkoutReader') and hasAuthority('SCOPE_readWorkouts')")
+  List<LearningPathProgress> listProgress(@PathVariable UUID id) {
+    return learningPathService.getProgress(id).stream()
+        .map(this::toResponse)
+        .toList();
+  }
+
+  @PostMapping(value = "/{id}/progress", consumes = MediaType.APPLICATION_JSON_VALUE)
+  @PreAuthorize("hasAuthority('APPROLE_WorkoutCreator') and hasAuthority('SCOPE_createWorkout')")
+  ResponseEntity<LearningPathProgress> logProgress(
+      @PathVariable UUID id,
+      @Valid @RequestBody ProgressRequest request) {
+    String comment = request.comment() == null ? null : request.comment().trim();
+    LearningPathProgressEntity saved = learningPathService.logProgress(
+        id, request.durationMinutes(), request.description().trim(),
+        comment == null || comment.isEmpty() ? null : comment);
+    return ResponseEntity.status(HttpStatus.CREATED).body(toResponse(saved));
+  }
+
   private LearningPath toResponse(LearningPathEntity entity) {
     return LearningPath.builder()
         .id(entity.getId())
@@ -139,5 +161,21 @@ public class LearningPathController {
   }
 
   public record ActivityRequest(@NotNull Boolean active) {
+  }
+
+  public record ProgressRequest(
+      @NotNull @Min(1) Integer durationMinutes,
+      @NotBlank @Size(max = 255) String description,
+      @Size(max = 2000) String comment) {
+  }
+
+  private LearningPathProgress toResponse(LearningPathProgressEntity entity) {
+    return LearningPathProgress.builder()
+        .id(entity.getId())
+        .createdAt(entity.getCreatedAt().toOffsetDateTime())
+        .durationMinutes(entity.getDurationMinutes())
+        .description(entity.getDescription())
+        .comment(entity.getComment())
+        .build();
   }
 }

--- a/server/src/main/java/mucsi96/traininglog/learning/LearningPathProgressEntity.java
+++ b/server/src/main/java/mucsi96/traininglog/learning/LearningPathProgressEntity.java
@@ -1,0 +1,39 @@
+package mucsi96.traininglog.learning;
+
+import java.time.ZonedDateTime;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Entity
+@Table(name = "learning_path_progress", schema = "training_log")
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class LearningPathProgressEntity {
+  @Id
+  private UUID id;
+
+  @Column(name = "path_id", nullable = false)
+  private UUID pathId;
+
+  @Column(name = "created_at", nullable = false)
+  private ZonedDateTime createdAt;
+
+  @Column(name = "duration_minutes", nullable = false)
+  private int durationMinutes;
+
+  @Column(nullable = false)
+  private String description;
+
+  @Column
+  private String comment;
+}

--- a/server/src/main/java/mucsi96/traininglog/learning/LearningPathProgressRepository.java
+++ b/server/src/main/java/mucsi96/traininglog/learning/LearningPathProgressRepository.java
@@ -1,0 +1,13 @@
+package mucsi96.traininglog.learning;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LearningPathProgressRepository extends JpaRepository<LearningPathProgressEntity, UUID> {
+  List<LearningPathProgressEntity> findByPathId(UUID pathId, Sort sort);
+
+  void deleteByPathId(UUID pathId);
+}

--- a/server/src/main/java/mucsi96/traininglog/learning/LearningPathService.java
+++ b/server/src/main/java/mucsi96/traininglog/learning/LearningPathService.java
@@ -32,6 +32,7 @@ public class LearningPathService {
 
   private final LearningPathRepository pathRepository;
   private final LearningPathActivityRepository activityRepository;
+  private final LearningPathProgressRepository progressRepository;
   private final LearningPathGenerationService generationService;
   private final ObjectMapper objectMapper;
   private final Clock clock;
@@ -81,6 +82,7 @@ public class LearningPathService {
     if (!pathRepository.existsById(id)) {
       throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Learning path not found");
     }
+    progressRepository.deleteByPathId(id);
     activityRepository.deleteByPathId(id);
     pathRepository.deleteById(id);
   }
@@ -114,6 +116,31 @@ public class LearningPathService {
     } else {
       activityRepository.deleteByPathIdAndDate(pathId, date);
     }
+  }
+
+  @Transactional
+  public LearningPathProgressEntity logProgress(UUID pathId, int durationMinutes, String description,
+      String comment) {
+    if (!pathRepository.existsById(pathId)) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Learning path not found");
+    }
+    LearningPathProgressEntity entry = LearningPathProgressEntity.builder()
+        .id(UUID.randomUUID())
+        .pathId(pathId)
+        .createdAt(now())
+        .durationMinutes(durationMinutes)
+        .description(description)
+        .comment(comment)
+        .build();
+    return progressRepository.save(entry);
+  }
+
+  @Transactional(readOnly = true)
+  public List<LearningPathProgressEntity> getProgress(UUID pathId) {
+    if (!pathRepository.existsById(pathId)) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Learning path not found");
+    }
+    return progressRepository.findByPathId(pathId, Sort.by(Sort.Direction.DESC, "createdAt"));
   }
 
   @Transactional(readOnly = true)

--- a/server/src/main/resources/api.yml
+++ b/server/src/main/resources/api.yml
@@ -758,6 +758,58 @@ paths:
         '404':
           description: Learning path not found
 
+  /learning-paths/{id}/progress:
+    parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/LearningPathProgress'
+        '404':
+          description: Learning path not found
+    post:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - durationMinutes
+                - description
+              properties:
+                durationMinutes:
+                  type: integer
+                  format: int32
+                  minimum: 1
+                description:
+                  type: string
+                  minLength: 1
+                  maxLength: 255
+                comment:
+                  type: string
+                  maxLength: 2000
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LearningPathProgress'
+        '404':
+          description: Learning path not found
+
 components:
   schemas:
     WeightMeasurement:
@@ -984,6 +1036,27 @@ components:
           type: string
         active:
           type: boolean
+    LearningPathProgress:
+      type: object
+      required:
+        - id
+        - createdAt
+        - durationMinutes
+        - description
+      properties:
+        id:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        durationMinutes:
+          type: integer
+          format: int32
+        description:
+          type: string
+        comment:
+          type: string
     PodiumMessage:
       type: object
       required:

--- a/server/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/server/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -789,3 +789,56 @@ databaseChangeLog:
                   defaultValueNumeric: 0
                   constraints:
                     nullable: false
+
+  - changeSet:
+      id: 28-create-learning-path-progress-table
+      author: mucsi96
+      changes:
+        - createTable:
+            tableName: learning_path_progress
+            columns:
+              - column:
+                  name: id
+                  type: uuid
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: path_id
+                  type: uuid
+                  constraints:
+                    nullable: false
+                    foreignKeyName: fk_learning_path_progress_path
+                    references: training_log.learning_path(id)
+              - column:
+                  name: created_at
+                  type: timestamp(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: duration_minutes
+                  type: integer
+                  constraints:
+                    nullable: false
+              - column:
+                  name: description
+                  type: varchar(255)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: comment
+                  type: varchar(2000)
+                  constraints:
+                    nullable: true
+        - createIndex:
+            tableName: learning_path_progress
+            indexName: idx_learning_path_progress_path_id
+            columns:
+              - column:
+                  name: path_id
+        - createIndex:
+            tableName: learning_path_progress
+            indexName: idx_learning_path_progress_created_at
+            columns:
+              - column:
+                  name: created_at

--- a/test/tests/learning.spec.ts
+++ b/test/tests/learning.spec.ts
@@ -2,8 +2,10 @@ import { test, expect } from '../fixtures';
 import {
   getGoldenDayDates,
   getLearningPathActivityRows,
+  getLearningPathProgressRows,
   getLearningPathRows,
   insertLearningPath,
+  insertLearningPathProgress,
   insertPushupSet,
   insertRide,
   setGoals,
@@ -178,6 +180,69 @@ test.describe('Learning paths', () => {
     await responsePromise;
     rows = await getLearningPathActivityRows();
     expect(rows).toHaveLength(0);
+  });
+
+  test('logs a progress entry from the learning path page', async ({ page }) => {
+    const pathId = randomUUID();
+    await insertLearningPath(pathId, 'My Path', minimalContent('Intro video'));
+
+    await page.goto(`/learning/${pathId}`);
+    const section = page.getByRole('region', { name: 'My Path' });
+    await section.getByRole('button', { name: 'Log progress' }).click();
+
+    const dialog = page.getByRole('dialog', { name: 'Log progress' });
+    await dialog.getByLabel('Time spent (minutes)').fill('45');
+    await dialog.getByLabel('What did you do?').fill('Watched the intro video');
+    await dialog
+      .getByLabel('Where did you reach?')
+      .fill('Stopped at chapter 2, ownership');
+    await dialog.getByRole('button', { name: 'Save' }).click();
+    await expect(dialog).toBeHidden();
+
+    const log = section.getByRole('region', { name: 'Progress log' });
+    await expect(log.getByText('Watched the intro video')).toBeVisible();
+    await expect(log.getByText('45 min', { exact: false })).toBeVisible();
+    await expect(
+      log.getByText('Stopped at chapter 2, ownership')
+    ).toBeVisible();
+
+    const rows = await getLearningPathProgressRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].path_id).toBe(pathId);
+    expect(rows[0].duration_minutes).toBe(45);
+    expect(rows[0].description).toBe('Watched the intro video');
+    expect(rows[0].comment).toBe('Stopped at chapter 2, ownership');
+  });
+
+  test('shows the latest continue comment at the top of the path', async ({ page }) => {
+    const pathId = randomUUID();
+    await insertLearningPath(pathId, 'My Path', minimalContent('Intro video'));
+    await insertLearningPathProgress(
+      randomUUID(),
+      pathId,
+      30,
+      'First session',
+      'Reached chapter 1',
+      daysAgoAt(2, 8)
+    );
+    await insertLearningPathProgress(
+      randomUUID(),
+      pathId,
+      60,
+      'Second session',
+      'Reached chapter 5',
+      daysAgoAt(1, 8)
+    );
+
+    await page.goto(`/learning/${pathId}`);
+    const section = page.getByRole('region', { name: 'My Path' });
+    const banner = section.getByRole('region', { name: 'Continue from' });
+    await expect(banner.getByText('Reached chapter 5')).toBeVisible();
+    await expect(banner.getByText('Reached chapter 1')).toBeHidden();
+
+    const log = section.getByRole('region', { name: 'Progress log' });
+    await expect(log.getByText('First session')).toBeVisible();
+    await expect(log.getByText('Second session')).toBeVisible();
   });
 
   test('hides the learning card on home when no paths exist', async ({ page }) => {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -30,6 +30,7 @@ export async function cleanupDb() {
   await query('DELETE FROM training_log.book');
   await query('DELETE FROM training_log.daily_task_completion');
   await query('DELETE FROM training_log.daily_task');
+  await query('DELETE FROM training_log.learning_path_progress');
   await query('DELETE FROM training_log.learning_path_activity');
   await query('DELETE FROM training_log.learning_path');
   await query('DELETE FROM training_log.oauth2_authorized_client');
@@ -347,6 +348,30 @@ export async function getLearningPathActivityRows() {
   const result = await query(
     `SELECT id, path_id, to_char(date, 'YYYY-MM-DD') AS date, created_at
      FROM training_log.learning_path_activity ORDER BY created_at ASC`
+  );
+  return result.rows;
+}
+
+export async function insertLearningPathProgress(
+  id: string,
+  pathId: string,
+  durationMinutes: number,
+  description: string,
+  comment: string | null = null,
+  createdAt: Date = new Date()
+) {
+  await query(
+    `INSERT INTO training_log.learning_path_progress
+       (id, path_id, created_at, duration_minutes, description, comment)
+     VALUES ($1, $2, $3, $4, $5, $6)`,
+    [id, pathId, createdAt, durationMinutes, description, comment]
+  );
+}
+
+export async function getLearningPathProgressRows() {
+  const result = await query(
+    `SELECT id, path_id, created_at, duration_minutes, description, comment
+     FROM training_log.learning_path_progress ORDER BY created_at ASC`
   );
   return result.rows;
 }


### PR DESCRIPTION
Let users record a study-session entry on a learning path: time spent
(minutes), a short description of what they did, and a comment noting
where they reached so they can continue next time.

- New learning_path_progress table (changeset 28) plus entity/repository
  mirroring the reading-progress pattern.
- Service.logProgress/getProgress (newest first) and progress cleanup on
  path delete; GET/POST /learning-paths/{id}/progress endpoints and the
  LearningPathProgress API schema.
- Detail page: "Log progress" dialog, a "Continue from" banner showing the
  latest comment, and a chronological progress log.
- Playwright coverage for logging an entry (UI + DB) and the continue banner.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015MJStadWnPCsogY9xougAz