### PR TITLE
Remove week view and make month the default timeframe

### DIFF
--- a/client/src/app/app.component.html
+++ b/client/src/app/app.component.html
@@ -9,13 +9,6 @@
         [routerLinkActiveOptions]="{ exact: true }"
         routerLinkActive
         ariaCurrentWhenActive="page"
-        >Week</a
-      >
-      <a
-        mat-button
-        routerLink="month"
-        routerLinkActive
-        ariaCurrentWhenActive="page"
         >Month</a
       >
       <a
@@ -51,13 +44,6 @@
         mat-menu-item
         routerLink=""
         [routerLinkActiveOptions]="{ exact: true }"
-        routerLinkActive
-        ariaCurrentWhenActive="page"
-        >Week</a
-      >
-      <a
-        mat-menu-item
-        routerLink="month"
         routerLinkActive
         ariaCurrentWhenActive="page"
         >Month</a

--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -7,13 +7,6 @@ export const routes: Routes = [
     loadComponent: () =>
       import('./home/home.component').then((m) => m.HomeComponent),
     pathMatch: 'full',
-    data: { period: 7 },
-    canActivate: [authGuard],
-  },
-  {
-    path: 'month',
-    loadComponent: () =>
-      import('./home/home.component').then((m) => m.HomeComponent),
     data: { period: 30 },
     canActivate: [authGuard],
   },

--- a/test/tests/pushups.spec.ts
+++ b/test/tests/pushups.spec.ts
@@ -83,10 +83,13 @@ test.describe('Pushups', () => {
 
     await page.goto('/');
     const section = page.getByRole('region', { name: 'Pushups' });
-    const chart = section.getByRole('img', { name: /chart/i });
-    const label = await chart.getAttribute('aria-label');
-    expect(label).toContain('70');
-    expect(label).toContain('25');
+    await expect(section.getByRole('img', { name: /chart/i })).toBeVisible();
+    // Each populated day is drawn as a bar labelled with its total: 30 + 40 = 70
+    // two days ago and 25 today. Asserting on the bar labels (rather than the
+    // chart's aria-label, which only enumerates the first 10 days) keeps this
+    // independent of how wide the selected period window is.
+    await expect(section.getByText('70', { exact: true })).toBeVisible();
+    await expect(section.getByText('25', { exact: true })).toBeVisible();
   });
 
   test('reflects the configured golden day pushup goal in the chart mark line', async ({ page }) => {

--- a/test/tests/ride.spec.ts
+++ b/test/tests/ride.spec.ts
@@ -23,18 +23,8 @@ test.describe('Ride', () => {
     await expect(page.getByText('2 h 20 min')).toBeVisible();
   });
 
-  test('should display ride stats for week', async ({ page }) => {
+  test('should display ride stats for the default month view', async ({ page }) => {
     await page.goto('/');
-    await expect(page.getByRole('heading', { name: 'Calories' })).toBeVisible();
-    await expect(page.getByText('3 678')).toBeVisible();
-    await expect(page.getByText('2 256 m')).toBeVisible();
-    await expect(page.getByText('91 km')).toBeVisible();
-    await expect(page.getByText('4 h 54 min')).toBeVisible();
-  });
-
-  test('should display ride stats for month', async ({ page }) => {
-    await page.goto('/');
-    await page.getByRole('link', { name: 'Month' }).click();
     await expect(page.getByRole('heading', { name: 'Calories' })).toBeVisible();
     await expect(page.getByText('4 324')).toBeVisible();
     await expect(page.getByText('2 664 m')).toBeVisible();
@@ -71,7 +61,7 @@ test.describe('Ride without activity in selected timerange', () => {
     await insertRide(400, 646, 11747.7, 3074, 'Old Ride', 'MountainBikeRide', 408, 210);
   });
 
-  test('should hide ride stats when no activity in the selected week', async ({ page }) => {
+  test('should hide ride stats when no activity in the selected timerange', async ({ page }) => {
     await page.goto('/');
     await expect(page.getByRole('heading', { name: 'Calories' })).toHaveCount(0);
     await expect(page.getByRole('heading', { name: 'Elevation gain' })).toHaveCount(0);

--- a/test/tests/weight.spec.ts
+++ b/test/tests/weight.spec.ts
@@ -41,40 +41,16 @@ test.describe('Weight', () => {
     await expect(ratioArticle.locator('.today-diff')).toHaveClass(/red/);
   });
 
-  test('should display weight diff for week', async ({ page }) => {
+  test('should display weight diff for the default month view', async ({ page }) => {
     await page.goto('/');
-    await expect(page.getByRole('heading', { name: 'Weight' })).toBeVisible();
-    await expect(page.getByText('↓ 2.2 kg')).toBeVisible();
-    await expect(page.getByText('↓ 9.0 kg')).toBeVisible();
-    await expect(page.getByText('↑ 0.8 %')).toBeVisible();
-  });
-
-  test('should display weight chart for week', async ({ page }) => {
-    await page.goto('/');
-    await expect(page.getByRole('heading', { name: 'Weight' })).toBeVisible();
-    const chart = page.locator('section:has-text("Weight") [role="img"]');
-    await expect(chart).toHaveAttribute('aria-label', /This is a chart with type Line chart/);
-    await expect(chart).toHaveAttribute('aria-label', chartLabel('89.4,'));
-    await expect(chart).toHaveAttribute('aria-label', chartLabel('88.3,'));
-    await expect(chart).toHaveAttribute('aria-label', chartLabel('87.7,'));
-    await expect(chart).toHaveAttribute('aria-label', chartLabel('87.5,'));
-    await expect(chart).toHaveAttribute('aria-label', chartLabel('87.2.'));
-    await expect(chart).not.toHaveAttribute('aria-label', chartLabel('108.9,'));
-    await expect(chart).not.toHaveAttribute('aria-label', chartLabel('98,'));
-  });
-
-  test('should display weight diff for month', async ({ page }) => {
-    await page.goto('/');
-    await page.getByRole('link', { name: 'Month' }).click();
     await expect(page.getByRole('heading', { name: 'Weight' })).toBeVisible();
     await expect(page.getByText('↓ 10.8 kg')).toBeVisible();
     await expect(page.getByText('↓ 12.7 kg')).toBeVisible();
     await expect(page.getByText('↑ 0.1 %')).toBeVisible();
   });
 
-  test('should display weight chart for month', async ({ page }) => {
+  test('should display weight chart for the default month view', async ({ page }) => {
     await page.goto('/');
-    await page.getByRole('link', { name: 'Month' }).click();
     await expect(page.getByRole('heading', { name: 'Weight' })).toBeVisible();
     const chart = page.locator('section:has-text("Weight") [role="img"]');
     await expect(chart).toHaveAttribute('aria-label', /This is a chart with type Line chart/);


### PR DESCRIPTION
## Summary
This PR removes the week view option from the application and makes the month view (30-day period) the default timeframe for all statistics and charts.

## Key Changes
- **Routing**: Removed the week route (`/`) with 7-day period and made the month route the default by moving its configuration to the root path
- **Navigation UI**: Removed "Week" navigation links from both the main navigation bar and dropdown menu in `app.component.html`
- **Tests**: Updated test descriptions and removed week-specific test cases:
  - Consolidated weight diff and chart tests to reference "default month view"
  - Consolidated ride stats tests to reference "default month view"
  - Removed separate week view test cases that verified 7-day statistics
  - Updated generic test description from "selected week" to "selected timerange"

## Implementation Details
The application now defaults to displaying a 30-day period for all metrics (weight, calories, elevation gain, etc.) without requiring users to explicitly select a month view. The week view has been completely removed from the UI and routing configuration.

https://claude.ai/code/session_013gUCeZpbzRgypVUzzxKJAP