### PR TITLE
Handle null weighted_average_watts for rides without power data

### DIFF
--- a/mock_strava_server/src/activities.ts
+++ b/mock_strava_server/src/activities.ts
@@ -18,7 +18,7 @@ type PushedActivity = {
   movingTime: number;
   calories: number;
   averageWatts: number;
-  weightedAverageWatts: number;
+  weightedAverageWatts: number | null;
   name: string;
   sportType: string;
   segmentEfforts: PushedSegmentEffort[];
@@ -56,7 +56,8 @@ export function pushActivity(req: Request, res: Response) {
     movingTime: body.movingTime ?? 4207,
     calories: body.calories ?? 870.2,
     averageWatts: body.averageWatts ?? 185.5,
-    weightedAverageWatts: body.weightedAverageWatts ?? 230,
+    weightedAverageWatts:
+      body.weightedAverageWatts === null ? null : body.weightedAverageWatts ?? 230,
     name: body.name ?? `Test activity ${id}`,
     sportType: body.sportType ?? 'MountainBikeRide',
     segmentEfforts,

--- a/server/src/main/java/mucsi96/traininglog/ftp/FtpService.java
+++ b/server/src/main/java/mucsi96/traininglog/ftp/FtpService.java
@@ -95,7 +95,7 @@ public class FtpService {
   private Map<ZonedDateTime, Computed> computeMeasurements(List<Ride> rides, List<Weight> weights, ZoneId zoneId) {
     TreeMap<LocalDate, Double> rideEftpByDay = rides.stream()
         .filter(ride -> ride.getMovingTime() >= MIN_RIDE_SECONDS)
-        .filter(ride -> ride.getWeightedAverageWatts() > 0)
+        .filter(ride -> ride.getWeightedAverageWatts() != null && ride.getWeightedAverageWatts() > 0)
         .collect(Collectors.groupingBy(
             ride -> ride.getCreatedAt().withZoneSameInstant(zoneId).toLocalDate(),
             TreeMap::new,

--- a/server/src/main/java/mucsi96/traininglog/rides/Ride.java
+++ b/server/src/main/java/mucsi96/traininglog/rides/Ride.java
@@ -34,7 +34,7 @@ public class Ride {
   private float totalElevationGain;
 
   @Column
-  private float weightedAverageWatts;
+  private Float weightedAverageWatts;
 
   @Column
   private float calories;

--- a/server/src/main/java/mucsi96/traininglog/strava/StravaActivityService.java
+++ b/server/src/main/java/mucsi96/traininglog/strava/StravaActivityService.java
@@ -126,6 +126,7 @@ public class StravaActivityService {
       }
 
       Float sufferScore = activity.getSufferScore() != null ? activity.getSufferScore() : summary.getSufferScore();
+      Integer weightedAverageWatts = activity.getWeightedAverageWatts();
       ZonedDateTime rideCreatedAt = activity.getStartDate().atZoneSameInstant(ZoneOffset.UTC);
 
       if (sufferScore == null) {
@@ -142,7 +143,7 @@ public class StravaActivityService {
           .movingTime(activity.getMovingTime())
           .distance(activity.getDistance())
           .totalElevationGain(activity.getTotalElevationGain())
-          .weightedAverageWatts(activity.getWeightedAverageWatts())
+          .weightedAverageWatts(weightedAverageWatts != null ? weightedAverageWatts.floatValue() : null)
           .calories(activity.getCalories())
           .sportType(activity.getSportType())
           .sufferScore(sufferScore)

--- a/test/tests/strava.spec.ts
+++ b/test/tests/strava.spec.ts
@@ -158,6 +158,20 @@ test.describe('Fitness when Strava back-fills suffer_score', () => {
   });
 });
 
+test.describe('Strava ride without power data', () => {
+  test('syncs a ride whose weighted_average_watts is null without crashing', async ({ page }) => {
+    // A ride recorded without a power meter has no weighted average watts.
+    await pushStravaActivity({ weightedAverageWatts: null });
+
+    await page.goto('/');
+    await expect(page.getByRole('heading', { name: 'Calories' })).toBeVisible();
+
+    const rows = await getRideRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0].weighted_average_watts).toBeNull();
+  });
+});
+
 test.describe('Fitness without a ride today', () => {
   test('decays yesterday fitness into today even before any activity', async ({ page }) => {
     // Yesterday: rides synced and fitness computed at the end of the day.

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -183,7 +183,7 @@ export async function insertRide(
 
 export async function getRideRows() {
   const result = await query(
-    'SELECT created_at, suffer_score FROM training_log.ride ORDER BY created_at ASC'
+    'SELECT created_at, suffer_score, weighted_average_watts FROM training_log.ride ORDER BY created_at ASC'
   );
   return result.rows;
 }
@@ -411,7 +411,7 @@ export type PushStravaActivityOptions = {
   movingTime?: number;
   calories?: number;
   averageWatts?: number;
-  weightedAverageWatts?: number;
+  weightedAverageWatts?: number | null;
   name?: string;
   sportType?: string;
   segmentEfforts?: PushStravaSegmentEffortOptions[];


### PR DESCRIPTION
## Summary
This PR adds support for syncing Strava rides that don't have power meter data (where `weighted_average_watts` is null) without crashing the application.

## Key Changes
- **Type safety**: Changed `weightedAverageWatts` from primitive `float` to nullable `Float` in the `Ride` entity to properly represent missing power data
- **Null handling in StravaActivityService**: Added explicit null check when converting `weightedAverageWatts` to float, preserving null values instead of using a default
- **Null-safe filtering in FtpService**: Updated the power data filter to check for null before comparing to 0, preventing NPE when computing FTP measurements
- **Test coverage**: Added test case verifying that rides without power data sync successfully and maintain null values
- **Mock server support**: Updated mock Strava server to properly handle null `weightedAverageWatts` values in test scenarios

## Implementation Details
- The change maintains backward compatibility: rides with power data continue to work as before
- Rides without power data are now synced but excluded from FTP calculations (which require valid power data)
- Test utilities updated to query and verify `weighted_average_watts` field in ride data

https://claude.ai/code/session_01JQ7WMZkg3m8yUZkfMGM3wV